### PR TITLE
refactor: Update IdleMonitor to monitor only mouse events - Modified …

### DIFF
--- a/packages/mac-app/TimeTrack/Services/IdleMonitor.swift
+++ b/packages/mac-app/TimeTrack/Services/IdleMonitor.swift
@@ -36,9 +36,8 @@ final class IdleMonitor {
     // MARK: - Private helpers
 
     private func setupEventMonitoring() {
+        // Monitor only mouse events to avoid requiring Input Monitoring permission
         let masks: [NSEvent.EventTypeMask] = [
-            .keyDown,
-            .keyUp,
             .mouseMoved,
             .leftMouseDown,
             .rightMouseDown,


### PR DESCRIPTION
…event monitoring setup to focus solely on mouse events, eliminating the need for Input Monitoring permission and streamlining user activity tracking.