### PR TITLE
Fix web app ignoring VITE_API_URL in production

### DIFF
--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -4,20 +4,8 @@ import { Project, Task } from "../store/slices/projectsSlice";
 import { TimeEntry } from "../store/slices/timeEntriesSlice";
 
 // Use environment variable or fallback to localhost:3011 for development
-// In browser, we need to use localhost, but in Docker we need to use container name
-const getApiBaseUrl = () => {
-  const envUrl = (import.meta as any).env.VITE_API_URL;
-
-  // If we're in a browser (client-side), always use localhost
-  if (typeof window !== 'undefined') {
-    return "http://localhost:3011";
-  }
-
-  // If we're on server-side (during SSR), use env variable or localhost
-  return envUrl || "http://localhost:3011";
-};
-
-const API_BASE_URL = getApiBaseUrl();
+const API_BASE_URL =
+  (import.meta as any).env.VITE_API_URL || "http://localhost:3011";
 
 class APIClient {
   private client: AxiosInstance;


### PR DESCRIPTION
## Summary
- Remove typeof window check that forced localhost:3011 for all browser environments
- Now respects VITE_API_URL environment variable in production deployments

## Technical details
The bug was introduced in commit 200d62c where a typeof window check was added to fix Docker SSR issues, but this caused production browsers to always use localhost:3011 instead of the configured VITE_API_URL.

## Test plan
- [ ] Verify development still works with localhost fallback
- [ ] Verify production uses VITE_API_URL when set
- [ ] Verify no browser permission prompts for local network access

Closes #47

Generated with [Claude Code](https://claude.com/claude-code)