### PR TITLE
Add missing password reset fields migration

### DIFF
--- a/packages/api/prisma/migrations/20251121200000_add_password_reset_fields/migration.sql
+++ b/packages/api/prisma/migrations/20251121200000_add_password_reset_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add password reset fields to users table
+ALTER TABLE "users"
+ADD COLUMN "passwordResetToken" TEXT,
+ADD COLUMN "passwordResetExpiresAt" TIMESTAMP(3);
+
+-- Create index on passwordResetToken for faster lookups
+CREATE INDEX "users_passwordResetToken_idx" ON "users"("passwordResetToken");


### PR DESCRIPTION
## Summary
- Add migration SQL file for passwordResetToken and passwordResetExpiresAt columns
- These fields were added to schema in PR #39 but migration was never committed

## Technical details
The *.sql gitignore pattern blocked the migration file from being committed. Using -f flag to force-add it.

## Database changes
- ALTER TABLE users ADD COLUMN passwordResetToken TEXT
- ALTER TABLE users ADD COLUMN passwordResetExpiresAt TIMESTAMP(3)  
- CREATE INDEX users_passwordResetToken_idx

## Test plan
- [x] Migration file created
- [ ] Deploy to production and verify migration runs
- [ ] Test login works after migration

Generated with [Claude Code](https://claude.com/claude-code)