### PR TITLE
Fix deployment environment variable loading and migration gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,9 +178,11 @@ storage/
 docker.env
 *.sql
 backup_*.sql
-# Allow specific init.sql files needed for container initialization
+# Allow specific SQL files needed for initialization and migrations
 !*/init.sql
 !init.sql
+!*/migrations/*/migration.sql
+!**/prisma/migrations/**/*.sql
 
 # Docker volumes and data
 postgres_data/

--- a/deploy.sh
+++ b/deploy.sh
@@ -137,6 +137,14 @@ deploy() {
         exit 1
     fi
 
+    # Export environment variables for docker-compose ${VAR} substitution
+    # The env_file directive loads vars into containers, but ${VAR} syntax
+    # in docker-compose.yml requires vars in the shell environment
+    log_info "Loading environment variables from $ENV_FILE"
+    set -a
+    source "$ENV_FILE"
+    set +a
+
     # Stop existing containers
     docker_compose -f "$compose_file" down
 

--- a/docker.env.example
+++ b/docker.env.example
@@ -44,22 +44,34 @@ VITE_API_URL=http://localhost:3011
 # Redis Configuration
 REDIS_PASSWORD=redis_secure_password
 
-# Production Configuration (for DigitalOcean deployment)
-# These should be uncommented and set with actual production values:
+# Production Configuration
+# CRITICAL: For production deployment, you MUST:
+# 1. Copy this file to docker.env (docker.env is gitignored for security)
+# 2. Update all values below with secure production credentials
+# 3. Never commit docker.env to git - it contains secrets
+
+# Port Configuration (can keep these defaults for production)
 # WEB_PORT=3010
 # API_PORT=3011
 # POSTGRES_PORT=3012
 # REDIS_PORT=3013
 
-# CRITICAL: These must be set for production PostgreSQL authentication to work
+# CRITICAL: These MUST be set for production PostgreSQL authentication to work
+# Generate strong passwords using: openssl rand -base64 32
 # POSTGRES_PASSWORD=your_very_secure_production_password_here
 # JWT_SECRET=your_very_long_random_production_jwt_secret_at_least_64_characters
 # REDIS_PASSWORD=your_secure_redis_production_password
 
 # Production URLs - update with your actual domain
-# ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+# ALLOWED_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
 # REACT_APP_API_URL=https://api.yourdomain.com
 # VITE_API_URL=https://api.yourdomain.com
+# APPLICATION_URL=https://app.yourdomain.com
 
 # Database URL is automatically constructed in docker-compose.yml using POSTGRES_PASSWORD
 # Redis URL is automatically configured in docker-compose.yml using REDIS_PASSWORD
+
+# DEPLOYMENT NOTES:
+# - The deploy.sh script automatically sources docker.env for environment variable substitution
+# - docker-compose.yml uses env_file to load variables into containers
+# - Both mechanisms are required: env_file for container runtime, sourcing for ${VAR} interpolation


### PR DESCRIPTION
## Summary
Root cause fixes for production deployment issues discovered during debugging:

### 1. Fix .gitignore to allow Prisma migration SQL files
- Add `!*/migrations/*/migration.sql` pattern
- Add `!**/prisma/migrations/**/*.sql` pattern  
- Prevents future migrations from being accidentally ignored by `*.sql` pattern

### 2. Fix deploy.sh to source docker.env before docker-compose
- Add `set -a && source docker.env && set +a` to deploy function
- Required for `${VAR}` substitution in docker-compose.yml
- `env_file` directive alone only loads vars into containers, doesn't export to shell

### 3. Improve docker.env.example with deployment instructions
- Add critical setup steps for production
- Explain dual environment variable mechanism
- Add password generation command hint

## Technical Details

**Problem:** Docker Compose uses two different mechanisms for environment variables:
1. `env_file: docker.env` - Loads variables INTO containers at runtime
2. `${VAR}` syntax - Requires variables in SHELL environment during compose parsing

The deploy script was only relying on #1, causing `${POSTGRES_PASSWORD}` to be empty.

**Impact:** Without these fixes, deployments require manual `source docker.env` workarounds.

## Test Plan
- [x] Verify .gitignore allows migration files: `git check-ignore` returns nothing
- [x] Verify backup files still ignored
- [ ] Test deployment script sources env vars correctly
- [ ] Verify production deployment works without manual intervention

Generated with [Claude Code](https://claude.com/claude-code)