### PR TITLE
Add live earnings display to iOS dashboard

### DIFF
--- a/packages/ios-app/Timetrack/Timetrack/ViewModels/DashboardViewModel.swift
+++ b/packages/ios-app/Timetrack/Timetrack/ViewModels/DashboardViewModel.swift
@@ -28,9 +28,18 @@ class DashboardViewModel: ObservableObject {
 
     // MARK: - Computed Properties
 
-    var todayEarningsFormatted: String {
-        guard let earnings = earnings else { return "$0.00" }
-        return String(format: "$%.2f", earnings.today.earnings)
+    // Calculate today's total earnings including live running timer
+    func calculateTodayTotalEarnings(currentTimerEarnings: Double?) -> Double {
+        guard let earnings = earnings else { return 0.0 }
+        let baseEarnings = earnings.today.earnings
+        let liveEarnings = currentTimerEarnings ?? 0.0
+        return baseEarnings + liveEarnings
+    }
+
+    // Format today's total earnings as currency string
+    func todayEarningsWithLive(currentTimerEarnings: Double?) -> String {
+        let total = calculateTodayTotalEarnings(currentTimerEarnings: currentTimerEarnings)
+        return String(format: "$%.2f", total)
     }
 
     var thisWeekEarningsFormatted: String {

--- a/packages/ios-app/Timetrack/Timetrack/Views/DashboardView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/DashboardView.swift
@@ -52,10 +52,10 @@ struct DashboardView: View {
                                 .padding()
                         } else {
                             HStack(spacing: 16) {
-                                // Today's Earnings Card
-                                EarningsCard(
+                                // Today's Earnings Card (with live updates)
+                                LiveEarningsCard(
                                     title: "Today",
-                                    earnings: dashboardViewModel.todayEarningsFormatted,
+                                    dashboardViewModel: dashboardViewModel,
                                     duration: dashboardViewModel.todayDurationFormatted
                                 )
 
@@ -256,6 +256,44 @@ struct LoadingEarningsCard: View {
                     .foregroundColor(.secondary)
 
                 Text("Loading...")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+}
+
+struct LiveEarningsCard: View {
+    @EnvironmentObject var timerViewModel: TimerViewModel
+    let title: String
+    let dashboardViewModel: DashboardViewModel
+    let duration: String
+
+    // Computed property that recalculates when timerViewModel.elapsedTime changes
+    private var liveEarnings: String {
+        dashboardViewModel.todayEarningsWithLive(currentTimerEarnings: timerViewModel.currentTimerLiveEarnings)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(title)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(liveEarnings)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+
+                Text(duration)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }


### PR DESCRIPTION
Implement real-time earnings updates in the iOS dashboard to match macOS functionality from PR #43.

Changes:
- DashboardViewModel: Add calculateTodayTotalEarnings() and todayEarningsWithLive() methods
- DashboardView: Create LiveEarningsCard component with reactive updates
- Replace static "Today" EarningsCard with LiveEarningsCard
- Wire up to existing timerViewModel.currentTimerLiveEarnings

The LiveEarningsCard automatically updates as the timer runs by accessing the timerViewModel's @Published elapsedTime through the currentTimerLiveEarnings computed property.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)