### PR TITLE
Remove redundant REACT_APP_API_URL environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ POSTGRES_PASSWORD     # Database password
 JWT_SECRET           # JWT signing secret
 EMAIL_HOST          # SMTP server for password reset
 ALLOWED_ORIGINS     # CORS origins (comma-separated)
-REACT_APP_API_URL   # API endpoint for UI
+VITE_API_URL        # API endpoint for UI
 ```
 
 ## Port Allocation

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -35,7 +35,7 @@ JWT_SECRET=your_very_long_random_secret_key_here
 
 # Optional - Customize as needed
 ALLOWED_ORIGINS=http://localhost:3010,https://yourdomain.com
-REACT_APP_API_URL=http://localhost:3011
+VITE_API_URL=http://localhost:3011
 ```
 
 ### 3. Start Development Environment
@@ -116,7 +116,7 @@ JWT_SECRET=very_long_random_string_at_least_32_characters
 
 # Domain configuration
 ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
-REACT_APP_API_URL=https://api.yourdomain.com
+VITE_API_URL=https://api.yourdomain.com
 
 # Optional
 LOG_LEVEL=info
@@ -224,7 +224,7 @@ docker volume prune             # Clean up volumes
 | `POSTGRES_PASSWORD` | ✅ | - | Database password |
 | `JWT_SECRET` | ✅ | - | JWT signing secret (32+ chars) |
 | `ALLOWED_ORIGINS` | ❌ | `http://localhost:3010` | CORS allowed origins |
-| `REACT_APP_API_URL` | ❌ | `http://localhost:3011` | API URL for frontend |
+| `VITE_API_URL` | ❌ | `http://localhost:3011` | API URL for frontend |
 
 ### Port Reference
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ JWT_SECRET=your_long_secret_key
 
 # Optional
 ALLOWED_ORIGINS=http://localhost:3010
-REACT_APP_API_URL=http://localhost:3011
+VITE_API_URL=http://localhost:3011
 APPLICATION_URL=http://localhost:3010  # Frontend URL for emails
 ```
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -69,12 +69,10 @@ services:
       target: production
       args:
         VITE_API_URL: ${VITE_API_URL}
-        REACT_APP_API_URL: ${REACT_APP_API_URL}
     container_name: timetrack-web-prod
     restart: unless-stopped
     env_file: docker.env
-    environment:
-      REACT_APP_API_URL: ${REACT_APP_API_URL}
+    # Environment variables handled at build time for production
     ports:
       - "${WEB_PORT:-3010}:80"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,12 +72,10 @@ services:
       target: development
       args:
         VITE_API_URL: ${VITE_API_URL:-http://localhost:3011}
-        REACT_APP_API_URL: ${REACT_APP_API_URL:-http://localhost:3011}
     container_name: timetrack-web
     restart: unless-stopped
     env_file: docker.env
     environment:
-      REACT_APP_API_URL: ${REACT_APP_API_URL:-http://localhost:3011}
       VITE_API_URL: ${VITE_API_URL:-http://localhost:3011}
     ports:
       - "${WEB_PORT:-3010}:5173"

--- a/docker.env.example
+++ b/docker.env.example
@@ -32,13 +32,9 @@ ENABLE_AGGRESSIVE_XSS_PROTECTION=false
 # CORS Configuration
 ALLOWED_ORIGINS=http://localhost:3010,https://yourdomain.com
 
-# React App Configuration
+# Vite Environment Variables (exposed to frontend)
 # For local development, use localhost
 # For production, use your domain or container-to-container communication
-REACT_APP_API_URL=http://localhost:3011
-
-# Vite Environment Variables (exposed to frontend)
-# This is what the Vite frontend actually uses
 VITE_API_URL=http://localhost:3011
 
 # Redis Configuration
@@ -64,7 +60,6 @@ REDIS_PASSWORD=redis_secure_password
 
 # Production URLs - update with your actual domain
 # ALLOWED_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
-# REACT_APP_API_URL=https://api.yourdomain.com
 # VITE_API_URL=https://api.yourdomain.com
 # APPLICATION_URL=https://app.yourdomain.com
 

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -3,9 +3,7 @@ FROM node:18-alpine AS build
 
 # Accept build arguments
 ARG VITE_API_URL
-ARG REACT_APP_API_URL
 ENV VITE_API_URL=$VITE_API_URL
-ENV REACT_APP_API_URL=$REACT_APP_API_URL
 
 # Set working directory
 WORKDIR /app
@@ -33,9 +31,7 @@ FROM node:18-alpine AS development
 
 # Accept build arguments
 ARG VITE_API_URL
-ARG REACT_APP_API_URL
 ENV VITE_API_URL=$VITE_API_URL
-ENV REACT_APP_API_URL=$REACT_APP_API_URL
 
 # Set working directory
 WORKDIR /app

--- a/packages/ui/env.example
+++ b/packages/ui/env.example
@@ -1,15 +1,11 @@
 # Environment Variables for TimeTrack UI
 
-# API Configuration for Vite (what the frontend actually uses)
+# API Configuration
 # Vite only exposes VITE_ prefixed variables to the browser
 VITE_API_URL="http://localhost:3011"
 
-# API Configuration for React (for consistency/other tools)
-REACT_APP_API_URL="http://localhost:3011"
-
 # For production - update with your actual domain
 # VITE_API_URL="https://api.yourdomain.com"
-# REACT_APP_API_URL="https://api.yourdomain.com"
 
 # Development Configuration
 # Vite dev server port (default: 5173)


### PR DESCRIPTION
Standardize on VITE_API_URL since this is a Vite project, not Create React App. Having both REACT_APP_API_URL and VITE_API_URL was redundant and error-prone.

Changes:
- Remove REACT_APP_API_URL from all Docker configurations
- Update documentation to reference only VITE_API_URL
- Clean up environment variable examples
- Simplify Dockerfile build args

🤖 Generated with [Claude Code](https://claude.com/claude-code)