### PR TITLE
Fix macOS Resume button not preserving project/task association

### DIFF
--- a/packages/api/src/routes/timeEntries.ts
+++ b/packages/api/src/routes/timeEntries.ts
@@ -311,6 +311,8 @@ router.post(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        projectId: true,
+        taskId: true,
         project: {
           select: {
             id: true,
@@ -410,6 +412,8 @@ router.post(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        projectId: true,
+        taskId: true,
         project: {
           select: {
             id: true,
@@ -467,6 +471,8 @@ router.get(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        projectId: true,
+        taskId: true,
         project: {
           select: {
             id: true,


### PR DESCRIPTION
## Summary
- Fixed Resume button in macOS menu bar dropdown starting timers without project/task association
- Added missing `projectId` and `taskId` fields to API responses

## Problem
When users clicked "Resume" on a stopped timer in the macOS app's menu bar dropdown, the timer would restart without any project or task association. The web app was working correctly.

## Root Cause
The API endpoints were not returning `projectId` and `taskId` fields in their responses, only the nested `project` and `task` objects. When the macOS app called `restartTimer(fromEntry:)`, it tried to access `entry.projectId` and `entry.taskId` but these were `nil`.

## Solution
Added `projectId: true` and `taskId: true` to the Prisma SELECT statements in three API endpoints:
- `/time-entries/start` - When starting a new timer
- `/time-entries/:id/stop` - When stopping a timer
- `/time-entries/current` - When fetching the current timer

## Test Plan
- [x] Start a timer with a project and task in macOS app
- [x] Stop the timer
- [x] Click Resume button in menu bar dropdown
- [x] Verify timer resumes with the same project and task
- [x] Verify web app still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)