### PR TITLE
Fix macOS Resume button by reading from nested API response objects

### DIFF
--- a/packages/mac-app/TimeTrack/ViewModels/TimerViewModel.swift
+++ b/packages/mac-app/TimeTrack/ViewModels/TimerViewModel.swift
@@ -209,8 +209,8 @@ class TimerViewModel: ObservableObject {
 
     func restartTimer(fromEntry entry: TimeEntry) async {
         await startTimer(
-            projectId: entry.projectId,
-            taskId: entry.taskId,
+            projectId: entry.project?.id,
+            taskId: entry.task?.id,
             description: entry.description
         )
     }
@@ -275,7 +275,7 @@ class TimerViewModel: ObservableObject {
         if let project = entry.project {
             return project.name
         }
-        return getProjectName(for: entry.projectId)
+        return getProjectName(for: entry.project?.id)
     }
 
     func getProjectColor(for projectId: String?) -> Color {
@@ -294,7 +294,7 @@ class TimerViewModel: ObservableObject {
         if let project = entry.project, let colorString = project.color {
             return Color(hex: colorString) ?? .gray
         }
-        return getProjectColor(for: entry.projectId)
+        return getProjectColor(for: entry.project?.id)
     }
 
     func getTaskName(for taskId: String?) -> String {
@@ -310,7 +310,7 @@ class TimerViewModel: ObservableObject {
         if let task = entry.task {
             return task.name
         }
-        return getTaskName(for: entry.taskId)
+        return getTaskName(for: entry.task?.id)
     }
 
     func getTaskFromAllProjects(taskId: String?) async -> String {


### PR DESCRIPTION
## Summary
- Fixed Resume button in macOS menu bar dropdown to correctly preserve project/task associations
- No API changes required - using existing response structure properly

## Problem
When users clicked "Resume" on a stopped timer in the macOS app's menu bar dropdown, the timer would restart without any project or task association.

## Root Cause
The macOS app was trying to access `entry.projectId` and `entry.taskId` directly, but the API provides this data through nested objects: `entry.project.id` and `entry.task.id`. The direct fields don't exist in the API response.

## Solution
Updated the macOS app to read from the correct paths:
- `restartTimer()` now uses `entry.project?.id` and `entry.task?.id`
- Helper methods that fall back to IDs also use the nested structure
- No API modifications needed - we're now properly using the existing API contract

## Why This Approach Is Better
- **No data duplication** - API doesn't send redundant projectId/taskId fields
- **Consistent API design** - All endpoints follow the same pattern of nested relations
- **Proper client implementation** - Client reads data from where the API provides it

## Test Plan
- [x] Start a timer with a project and task in macOS app
- [x] Stop the timer
- [x] Click Resume button in menu bar dropdown
- [x] Verify timer resumes with the same project and task
- [x] Verify project name and color display correctly
- [x] Verify task name displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)