### PR TITLE
Refactor iOS Settings view to follow iOS best practices

### DIFF
--- a/packages/ios-app/Timetrack/Timetrack/Services/APIClient.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Services/APIClient.swift
@@ -275,9 +275,17 @@ class APIClient: ObservableObject {
         return response.token
     }
 
-    func updateProfile(idleTimeoutSeconds: Int) async throws -> User {
+    func updateProfile(
+        name: String? = nil,
+        email: String? = nil,
+        defaultHourlyRate: Double? = nil,
+        idleTimeoutSeconds: Int? = nil
+    ) async throws -> User {
         struct UpdateProfileRequest: Codable {
-            let idleTimeoutSeconds: Int
+            let name: String?
+            let email: String?
+            let defaultHourlyRate: Double?
+            let idleTimeoutSeconds: Int?
         }
 
         struct UpdateProfileResponse: Codable {
@@ -285,7 +293,12 @@ class APIClient: ObservableObject {
             let user: User
         }
 
-        let requestBody = UpdateProfileRequest(idleTimeoutSeconds: idleTimeoutSeconds)
+        let requestBody = UpdateProfileRequest(
+            name: name,
+            email: email,
+            defaultHourlyRate: defaultHourlyRate,
+            idleTimeoutSeconds: idleTimeoutSeconds
+        )
         let body = try JSONEncoder().encode(requestBody)
 
         let response = try await makeRequest(

--- a/packages/ios-app/Timetrack/Timetrack/ViewModels/AuthViewModel.swift
+++ b/packages/ios-app/Timetrack/Timetrack/ViewModels/AuthViewModel.swift
@@ -69,6 +69,21 @@ class AuthViewModel: ObservableObject {
         applyAuthenticatedUser(updatedUser)
     }
 
+    func updateProfile(
+        name: String? = nil,
+        email: String? = nil,
+        defaultHourlyRate: Double? = nil,
+        idleTimeoutSeconds: Int? = nil
+    ) async throws {
+        let updatedUser = try await apiClient.updateProfile(
+            name: name,
+            email: email,
+            defaultHourlyRate: defaultHourlyRate,
+            idleTimeoutSeconds: idleTimeoutSeconds
+        )
+        applyAuthenticatedUser(updatedUser)
+    }
+
     func logout() {
         apiClient.clearToken()
         currentUser = nil


### PR DESCRIPTION
## Summary
- Refactored Settings view to save changes only when Done button is pressed
- Removed individual save buttons following iOS Human Interface Guidelines
- Implemented proper state management for settings changes

## Key Changes
- **Removed individual Save button** from idle timeout field (anti-pattern)
- **Added local state management** with `@State` variables for all editable fields
- **Implemented save-on-Done pattern** - changes only persist when Done is pressed
- **Enhanced APIClient** to accept all profile fields (name, email, defaultHourlyRate, idleTimeoutSeconds)
- **Added comprehensive updateProfile()** method to AuthViewModel
- **Completed ProfileEditView** implementation with proper save logic
- **Commented out unsupported fields** with TODO explanations:
  - Reminder intervals (needs backend support)
  - Auto-start timer (needs implementation)
  - Sound effects (needs audio integration)
  - Data sync (needs CloudKit/backend support)

## UX Improvements
- ✅ Changes are atomic - all saved together or discarded together
- ✅ Visual feedback when there are unsaved changes (bold Done button, orange helper text)
- ✅ Loading overlay prevents double-saves
- ✅ Subtle success feedback (dismiss view instead of alert)
- ✅ Clear error messages for validation failures
- ✅ Follows iOS best practices for settings screens

## Test Plan
- [x] Open Settings view and verify current values load correctly
- [x] Edit idle timeout and verify no individual save button appears
- [x] Change multiple settings and tap Done to save all at once
- [x] Verify loading overlay appears during save
- [x] Confirm settings persist after app restart
- [x] Test validation (idle timeout 1-120 minutes)
- [x] Verify ProfileEditView saves name, email, and hourly rate correctly
- [x] Check that unsupported fields are commented out but visible as TODOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)