### PR TITLE
Redesign iOS app with premium dark aesthetic to match macOS

### DIFF
--- a/packages/ios-app/Timetrack/Timetrack.xcodeproj/xcshareddata/xcschemes/Timetrack.xcscheme
+++ b/packages/ios-app/Timetrack/Timetrack.xcodeproj/xcshareddata/xcschemes/Timetrack.xcscheme
@@ -54,7 +54,7 @@
          <EnvironmentVariable
             key = "TIMETRACK_API_URL"
             value = "http://localhost:3011"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
+++ b/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
@@ -417,16 +417,85 @@ class TimerViewModel: ObservableObject {
     }
 }
 
-// MARK: - App Theme
+// MARK: - Premium App Theme
 struct AppTheme {
-    static let primary = Color(hex: "#FFFFFF") ?? .white
-    static let secondary = Color(hex: "#9CA3AF") ?? .secondary
-    static let accent = Color(hex: "#3B82F6") ?? .blue
+    // Core colors - Rich, premium dark palette
+    static let primary = Color(hex: "#F8FAFC") ?? .white
+    static let secondary = Color(hex: "#94A3B8") ?? .secondary
+    static let tertiary = Color(hex: "#64748B") ?? .gray
+
+    // Accent colors - Vibrant gradient-ready
+    static let accent = Color(hex: "#6366F1") ?? .blue  // Indigo
+    static let accentSecondary = Color(hex: "#8B5CF6") ?? .purple  // Violet
+
+    // Backgrounds - Original dark palette
     static let background = Color(hex: "#161516") ?? .black
+    static let backgroundElevated = Color(hex: "#1A1A1A") ?? .black
     static let cardBackground = Color(hex: "#1F1F1F") ?? .gray
-    static let success = Color(hex: "#10B981") ?? .green
-    static let error = Color(hex: "#EF4444") ?? .red
+    static let cardBackgroundHover = Color(hex: "#2A2A2A") ?? .gray
+
+    // Semantic colors - Rich and bold
+    static let success = Color(hex: "#22C55E") ?? .green
+    static let successMuted = Color(hex: "#16A34A") ?? .green
+    static let error = Color(hex: "#F43F5E") ?? .red  // Rose for premium feel
+    static let errorMuted = Color(hex: "#E11D48") ?? .red
     static let warning = Color(hex: "#F59E0B") ?? .orange
+
+    // Earnings highlight - Green for live money display
+    static let earnings = Color(hex: "#22C55E") ?? .green
+    static let earningsMuted = Color(hex: "#16A34A") ?? .green
+
+    // Border colors
+    static let border = Color(hex: "#27272A") ?? .gray
+    static let borderSubtle = Color(hex: "#1F1F23") ?? .gray
+    static let borderAccent = (Color(hex: "#6366F1") ?? .blue).opacity(0.3)
+
+    // Gradients
+    static let accentGradient = LinearGradient(
+        colors: [Color(hex: "#6366F1") ?? .blue, Color(hex: "#8B5CF6") ?? .purple],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let successGradient = LinearGradient(
+        colors: [Color(hex: "#22C55E") ?? .green, Color(hex: "#10B981") ?? .green],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let errorGradient = LinearGradient(
+        colors: [Color(hex: "#F43F5E") ?? .red, Color(hex: "#E11D48") ?? .red],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let cardGradient = LinearGradient(
+        colors: [Color(hex: "#18181B") ?? .gray, Color(hex: "#111113") ?? .black],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    // Typography weights
+    static let fontWeightLight: Font.Weight = .light
+    static let fontWeightRegular: Font.Weight = .regular
+    static let fontWeightMedium: Font.Weight = .medium
+    static let fontWeightSemibold: Font.Weight = .semibold
+    static let fontWeightBold: Font.Weight = .bold
+
+    // Spacing system
+    static let spacingXS: CGFloat = 4
+    static let spacingSM: CGFloat = 8
+    static let spacingMD: CGFloat = 12
+    static let spacingLG: CGFloat = 16
+    static let spacingXL: CGFloat = 24
+    static let spacing2XL: CGFloat = 32
+
+    // Border radius
+    static let radiusSM: CGFloat = 6
+    static let radiusMD: CGFloat = 10
+    static let radiusLG: CGFloat = 14
+    static let radiusXL: CGFloat = 20
+    static let radiusFull: CGFloat = 100
 }
 
 // MARK: - Color Extension

--- a/packages/ios-app/Timetrack/Timetrack/Views/DashboardView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/DashboardView.swift
@@ -9,113 +9,123 @@ struct DashboardView: View {
 
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
-                // Fixed Timer Section at the top
-                TimerView(
-                    onRefresh: {
-                        Task {
-                            withAnimation(.linear(duration: 1)) {
-                                rotationDegrees = 360
-                            }
-                            await timerViewModel.loadInitialData()
-                            await dashboardViewModel.loadDashboardEarnings()
-                            // Reset without animation
-                            rotationDegrees = 0
-                        }
-                    },
-                    onSettings: {
-                        showingSettings = true
-                    },
-                    rotationDegrees: rotationDegrees,
-                    isRefreshing: timerViewModel.isRefreshing
-                )
-                .padding()
-                .background(AppTheme.background)
-                .cornerRadius(12)
-                .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
-                .padding(.horizontal)
-                .padding(.top)
+            ZStack {
+                // Dark background
+                AppTheme.background
+                    .ignoresSafeArea()
 
-                // Scrollable content below TimerView
-                ScrollView {
-                    VStack(spacing: 16) {
-                        // Earnings Cards Section
-                        if dashboardViewModel.isLoading {
-                            HStack(spacing: 16) {
-                                LoadingEarningsCard(title: "Today")
-                                LoadingEarningsCard(title: "This Week")
-                            }
-                        } else if let errorMessage = dashboardViewModel.errorMessage {
-                            Text("Failed to load earnings: \(errorMessage)")
-                                .foregroundColor(AppTheme.error)
-                                .font(.caption)
-                                .padding()
-                        } else {
-                            HStack(spacing: 16) {
-                                // Today's Earnings Card (with live updates)
-                                LiveEarningsCard(
-                                    title: "Today",
-                                    dashboardViewModel: dashboardViewModel,
-                                    duration: dashboardViewModel.todayDurationFormatted
-                                )
+                VStack(spacing: 0) {
+                    // Header
+                    HStack {
+                        Text("TimeTrack")
+                            .font(.system(size: 28, weight: .bold, design: .rounded))
+                            .foregroundColor(AppTheme.primary)
 
-                                // This Week's Earnings Card
-                                EarningsCard(
-                                    title: "This Week",
-                                    earnings: dashboardViewModel.thisWeekEarningsFormatted,
-                                    duration: dashboardViewModel.thisWeekDurationFormatted
-                                )
-                            }
-                        }
+                        Spacer()
 
-                        // Recent Time Entries Section
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text("Recent Entries")
-                                .font(.headline)
-                                .fontWeight(.semibold)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-
-                            // Time entries list
-                            if timerViewModel.recentEntries.isEmpty {
-                                VStack(spacing: 12) {
-                                    Text("No time entries yet")
-                                        .font(.headline)
-                                        .foregroundColor(.secondary)
+                        HStack(spacing: AppTheme.spacingMD) {
+                            Button(action: {
+                                Task {
+                                    withAnimation(.linear(duration: 1)) {
+                                        rotationDegrees = 360
+                                    }
+                                    await timerViewModel.loadInitialData()
+                                    await dashboardViewModel.loadDashboardEarnings()
+                                    rotationDegrees = 0
                                 }
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 20)
+                            }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.system(size: 18, weight: .medium))
+                                    .foregroundColor(AppTheme.secondary)
+                            }
+                            .rotationEffect(.degrees(rotationDegrees))
+                            .disabled(timerViewModel.isRefreshing)
+
+                            Button(action: {
+                                showingSettings = true
+                            }) {
+                                Image(systemName: "gearshape")
+                                    .font(.system(size: 18, weight: .medium))
+                                    .foregroundColor(AppTheme.secondary)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, AppTheme.spacingLG)
+                    .padding(.top, AppTheme.spacingMD)
+                    .padding(.bottom, AppTheme.spacingSM)
+
+                    // Fixed Timer Section at the top
+                    TimerView()
+                    .padding(AppTheme.spacingLG)
+                    .background(AppTheme.cardBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusLG))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.radiusLG)
+                            .stroke(AppTheme.border, lineWidth: 1)
+                    )
+                    .padding(.horizontal, AppTheme.spacingLG)
+                    .padding(.top, AppTheme.spacingSM)
+
+                    // Scrollable content below TimerView
+                    ScrollView {
+                        VStack(spacing: AppTheme.spacingLG) {
+                            // Earnings Cards Section
+                            if dashboardViewModel.isLoading {
+                                HStack(spacing: AppTheme.spacingMD) {
+                                    LoadingEarningsCard(title: "Today")
+                                    LoadingEarningsCard(title: "This Week")
+                                }
+                            } else if let errorMessage = dashboardViewModel.errorMessage {
+                                Text("Failed to load earnings: \(errorMessage)")
+                                    .foregroundColor(AppTheme.error)
+                                    .font(.system(size: 13))
+                                    .padding()
                             } else {
-                                LazyVStack(spacing: 12) {
-                                    ForEach(timerViewModel.recentEntries) { entry in
-                                        TimeEntryRow(entry: entry)
+                                HStack(spacing: AppTheme.spacingMD) {
+                                    // Today's Earnings Card (with live updates)
+                                    LiveEarningsCard(
+                                        title: "Today",
+                                        dashboardViewModel: dashboardViewModel,
+                                        duration: dashboardViewModel.todayDurationFormatted
+                                    )
+
+                                    // This Week's Earnings Card
+                                    EarningsCard(
+                                        title: "This Week",
+                                        earnings: dashboardViewModel.thisWeekEarningsFormatted,
+                                        duration: dashboardViewModel.thisWeekDurationFormatted
+                                    )
+                                }
+                            }
+
+                            // Recent Time Entries Section
+                            VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+                                Text("Recent Entries")
+                                    .font(.system(size: 17, weight: .semibold))
+                                    .foregroundColor(AppTheme.primary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                                // Time entries list
+                                if timerViewModel.recentEntries.isEmpty {
+                                    PremiumEmptyState(
+                                        icon: "clock.arrow.circlepath",
+                                        title: "No time entries yet",
+                                        subtitle: "Start tracking to see your entries here"
+                                    )
+                                } else {
+                                    LazyVStack(spacing: AppTheme.spacingMD) {
+                                        ForEach(timerViewModel.recentEntries) { entry in
+                                            TimeEntryRow(entry: entry)
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                    .padding()
-                }
-            }
-            .background(Color(UIColor.systemBackground))
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    HStack {
-                        Text("TimeTrack")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
-                        
-                        Button(action: {
-                            authViewModel.logout()
-                        }) {
-                            Image(systemName: "rectangle.portrait.and.arrow.right")
-                                .font(.title3)
-                                .foregroundColor(.secondary)
-                        }
+                        .padding(AppTheme.spacingLG)
                     }
                 }
             }
+            .navigationBarHidden(true)
             .sheet(isPresented: $showingSettings) {
                 SettingsView()
             }
@@ -133,73 +143,86 @@ struct DashboardView: View {
 struct TimeEntryRow: View {
     @EnvironmentObject var timerViewModel: TimerViewModel
     let entry: TimeEntry
-    @State private var isBlinking = false
+    @State private var borderOpacity: Double = 0.5
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    // Use shared project display component
-                    ProjectTaskDisplayView(
-                        entry: entry,
-                        style: .full
-                    )
-                    .opacity(entry.isRunning ? (isBlinking ? 0.3 : 1.0) : 1.0)
-                    .onAppear {
-                        if entry.isRunning {
-                            withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
-                                isBlinking = true
-                            }
-                        }
-                    }
-                    .onChange(of: entry.isRunning) { newValue in
-                        if newValue {
-                            withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
-                                isBlinking = true
-                            }
-                        } else {
-                            withAnimation(.easeInOut(duration: 0.3)) {
-                                isBlinking = false
-                            }
-                        }
-                    }
+        HStack(spacing: AppTheme.spacingMD) {
+            // Project color indicator
+            Circle()
+                .fill(timerViewModel.getProjectColor(for: entry))
+                .frame(width: 8, height: 8)
 
-                    Spacer()
+            // Project/task info and description
+            VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
+                HStack(spacing: AppTheme.spacingSM) {
+                    Text(entry.project?.name ?? "No Project")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(AppTheme.primary)
+                        .lineLimit(1)
 
-                    // Duration display
-                    if !entry.isRunning {
-                        Text(entry.formattedDurationShort)
-                            .font(.headline)
-                            .fontWeight(.medium)
+                    if let task = entry.task {
+                        Text(task.name)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.tertiary)
+                            .lineLimit(1)
                     }
                 }
 
                 if let description = entry.description, !description.isEmpty {
                     Text(description)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .font(.system(size: 13))
+                        .foregroundColor(AppTheme.tertiary)
                         .lineLimit(1)
                 }
             }
-            .padding()
-            .frame(maxWidth: .infinity)
-            .cornerRadius(8)
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(entry.isRunning ? AppTheme.success.opacity(0.5) : Color.primary.opacity(0.1), lineWidth: 0.5)
-            )
 
-            // Restart button
-            if !timerViewModel.isRunning {
+            Spacer()
+
+            // Duration display
+            Text(entry.formattedDurationShort)
+                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .foregroundColor(AppTheme.primary)
+
+            // Play button (only when no timer running)
+            if !timerViewModel.isRunning && !entry.isRunning {
                 Button(action: {
                     Task {
                         await timerViewModel.restartTimer(fromEntry: entry)
                     }
                 }) {
-                    Image(systemName: "play.circle.fill")
-                        .font(.title2)
-                        .foregroundColor(AppTheme.success)
+                    ZStack {
+                        Circle()
+                            .stroke(AppTheme.success, lineWidth: 2)
+                            .frame(width: 36, height: 36)
+
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(AppTheme.success)
+                    }
                 }
+            }
+        }
+        .padding(AppTheme.spacingMD)
+        .background(AppTheme.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                .stroke(entry.isRunning ? AppTheme.success.opacity(borderOpacity) : AppTheme.border, lineWidth: entry.isRunning ? 2 : 1)
+        )
+        .onAppear {
+            if entry.isRunning {
+                withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
+                    borderOpacity = 1.0
+                }
+            }
+        }
+        .onChange(of: entry.isRunning) { newValue in
+            if newValue {
+                withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
+                    borderOpacity = 1.0
+                }
+            } else {
+                borderOpacity = 0.5
             }
         }
     }
@@ -211,59 +234,67 @@ struct EarningsCard: View {
     let duration: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text(title)
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-            }
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(AppTheme.secondary)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
                 Text(earnings)
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .foregroundColor(.primary)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundColor(AppTheme.primary)
 
                 Text(duration)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 13))
+                    .foregroundColor(AppTheme.tertiary)
             }
         }
-        .padding()
+        .padding(AppTheme.spacingLG)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(12)
+        .background(AppTheme.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
     }
 }
 
 struct LoadingEarningsCard: View {
     let title: String
+    @State private var isShimmering = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text(title)
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-            }
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(AppTheme.secondary)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("...")
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(AppTheme.border)
+                    .frame(width: 80, height: 28)
+                    .opacity(isShimmering ? 0.5 : 1)
 
-                Text("Loading...")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(AppTheme.border)
+                    .frame(width: 60, height: 16)
+                    .opacity(isShimmering ? 0.5 : 1)
             }
         }
-        .padding()
+        .padding(AppTheme.spacingLG)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(12)
+        .background(AppTheme.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
+                isShimmering = true
+            }
+        }
     }
 }
 
@@ -279,29 +310,29 @@ struct LiveEarningsCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text(title)
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-            }
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(AppTheme.secondary)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
                 Text(liveEarnings)
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .foregroundColor(.primary)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundColor(AppTheme.primary)
 
                 Text(duration)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 13))
+                    .foregroundColor(AppTheme.tertiary)
             }
         }
-        .padding()
+        .padding(AppTheme.spacingLG)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(12)
+        .background(AppTheme.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
     }
 }
 

--- a/packages/ios-app/Timetrack/Timetrack/Views/LegalDocumentsView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/LegalDocumentsView.swift
@@ -4,141 +4,229 @@ struct LegalDocumentsView: View {
     @Environment(\.dismiss) var dismiss
     @State private var showingPrivacyPolicy = false
     @State private var showingTermsOfService = false
-    
+
     var body: some View {
         NavigationView {
-            List {
-                Section {
-                    Button(action: {
-                        showingPrivacyPolicy = true
-                    }) {
-                        HStack {
-                            Image(systemName: "lock.shield")
-                                .foregroundColor(.blue)
-                                .font(.title2)
-                            
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Privacy Policy")
-                                    .foregroundColor(.primary)
-                                    .font(.headline)
-                                
-                                Text("How we collect, use, and protect your data")
-                                    .foregroundColor(.secondary)
-                                    .font(.caption)
+            ZStack {
+                AppTheme.background
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: AppTheme.spacingLG) {
+                        // Legal Documents Section
+                        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+                            Text("Legal Documents")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.secondary)
+                                .textCase(.uppercase)
+
+                            VStack(spacing: 0) {
+                                Button(action: {
+                                    showingPrivacyPolicy = true
+                                }) {
+                                    HStack(spacing: AppTheme.spacingMD) {
+                                        Image(systemName: "lock.shield")
+                                            .font(.system(size: 20))
+                                            .foregroundColor(AppTheme.accent)
+
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Privacy Policy")
+                                                .font(.system(size: 14, weight: .medium))
+                                                .foregroundColor(AppTheme.primary)
+
+                                            Text("How we collect, use, and protect your data")
+                                                .font(.system(size: 12))
+                                                .foregroundColor(AppTheme.secondary)
+                                        }
+
+                                        Spacer()
+
+                                        Image(systemName: "chevron.right")
+                                            .font(.system(size: 12, weight: .medium))
+                                            .foregroundColor(AppTheme.tertiary)
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                }
+
+                                Divider()
+                                    .background(AppTheme.border)
+
+                                Button(action: {
+                                    showingTermsOfService = true
+                                }) {
+                                    HStack(spacing: AppTheme.spacingMD) {
+                                        Image(systemName: "doc.text")
+                                            .font(.system(size: 20))
+                                            .foregroundColor(AppTheme.accent)
+
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Terms of Service")
+                                                .font(.system(size: 14, weight: .medium))
+                                                .foregroundColor(AppTheme.primary)
+
+                                            Text("Rules and guidelines for using TimeTrack")
+                                                .font(.system(size: 12))
+                                                .foregroundColor(AppTheme.secondary)
+                                        }
+
+                                        Spacer()
+
+                                        Image(systemName: "chevron.right")
+                                            .font(.system(size: 12, weight: .medium))
+                                            .foregroundColor(AppTheme.tertiary)
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                }
                             }
-                            
-                            Spacer()
-                            
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.secondary)
-                                .font(.caption)
+                            .background(AppTheme.cardBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                                    .stroke(AppTheme.border, lineWidth: 1)
+                            )
+
+                            Text("These documents explain your rights and our responsibilities when you use TimeTrack.")
+                                .font(.system(size: 12))
+                                .foregroundColor(AppTheme.tertiary)
                         }
-                        .padding(.vertical, 4)
-                    }
-                    
-                    Button(action: {
-                        showingTermsOfService = true
-                    }) {
-                        HStack {
-                            Image(systemName: "doc.text")
-                                .foregroundColor(.blue)
-                                .font(.title2)
-                            
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Terms of Service")
-                                    .foregroundColor(.primary)
-                                    .font(.headline)
-                                
-                                Text("Rules and guidelines for using TimeTrack")
-                                    .foregroundColor(.secondary)
-                                    .font(.caption)
+
+                        // About Section
+                        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+                            Text("About")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.secondary)
+                                .textCase(.uppercase)
+
+                            VStack(spacing: 0) {
+                                HStack {
+                                    Text("Version")
+                                        .font(.system(size: 14, weight: .medium))
+                                        .foregroundColor(AppTheme.primary)
+
+                                    Spacer()
+
+                                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(AppTheme.secondary)
+                                }
+                                .padding(AppTheme.spacingMD)
+
+                                Divider()
+                                    .background(AppTheme.border)
+
+                                HStack {
+                                    Text("Build")
+                                        .font(.system(size: 14, weight: .medium))
+                                        .foregroundColor(AppTheme.primary)
+
+                                    Spacer()
+
+                                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(AppTheme.secondary)
+                                }
+                                .padding(AppTheme.spacingMD)
+
+                                Divider()
+                                    .background(AppTheme.border)
+
+                                HStack {
+                                    Text("Last Updated")
+                                        .font(.system(size: 14, weight: .medium))
+                                        .foregroundColor(AppTheme.primary)
+
+                                    Spacer()
+
+                                    Text("January 2025")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(AppTheme.secondary)
+                                }
+                                .padding(AppTheme.spacingMD)
                             }
-                            
-                            Spacer()
-                            
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.secondary)
-                                .font(.caption)
+                            .background(AppTheme.cardBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                                    .stroke(AppTheme.border, lineWidth: 1)
+                            )
                         }
-                        .padding(.vertical, 4)
+
+                        // Contact Section
+                        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+                            Text("Questions?")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.secondary)
+                                .textCase(.uppercase)
+
+                            VStack(spacing: 0) {
+                                Button(action: {
+                                    if let url = URL(string: "mailto:privacy@timetrack.app?subject=Privacy%20Question") {
+                                        UIApplication.shared.open(url)
+                                    }
+                                }) {
+                                    HStack(spacing: AppTheme.spacingMD) {
+                                        Image(systemName: "envelope")
+                                            .font(.system(size: 16))
+                                            .foregroundColor(AppTheme.accent)
+
+                                        Text("Contact Privacy Team")
+                                            .font(.system(size: 14, weight: .medium))
+                                            .foregroundColor(AppTheme.primary)
+
+                                        Spacer()
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                }
+
+                                Divider()
+                                    .background(AppTheme.border)
+
+                                Button(action: {
+                                    if let url = URL(string: "mailto:support@timetrack.app?subject=Terms%20Question") {
+                                        UIApplication.shared.open(url)
+                                    }
+                                }) {
+                                    HStack(spacing: AppTheme.spacingMD) {
+                                        Image(systemName: "questionmark.circle")
+                                            .font(.system(size: 16))
+                                            .foregroundColor(AppTheme.accent)
+
+                                        Text("Contact Support")
+                                            .font(.system(size: 14, weight: .medium))
+                                            .foregroundColor(AppTheme.primary)
+
+                                        Spacer()
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                }
+                            }
+                            .background(AppTheme.cardBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                                    .stroke(AppTheme.border, lineWidth: 1)
+                            )
+
+                            Text("If you have questions about these documents or our policies, we're here to help.")
+                                .font(.system(size: 12))
+                                .foregroundColor(AppTheme.tertiary)
+                        }
                     }
-                } header: {
-                    Text("Legal Documents")
-                } footer: {
-                    Text("These documents explain your rights and our responsibilities when you use TimeTrack.")
+                    .padding(AppTheme.spacingLG)
                 }
-                
-                Section {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("App Information")
-                            .font(.headline)
-                        
-                        HStack {
-                            Text("Version:")
-                            Spacer()
-                            Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
-                                .foregroundColor(.secondary)
+                .navigationTitle("Legal & Privacy")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            dismiss()
                         }
-                        
-                        HStack {
-                            Text("Build:")
-                            Spacer()
-                            Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
-                                .foregroundColor(.secondary)
-                        }
-                        
-                        HStack {
-                            Text("Last Updated:")
-                            Spacer()
-                            Text("January 2025")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                } header: {
-                    Text("About")
-                }
-                
-                Section {
-                    Button(action: {
-                        if let url = URL(string: "mailto:privacy@timetrack.app?subject=Privacy%20Question") {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        HStack {
-                            Image(systemName: "envelope")
-                                .foregroundColor(.blue)
-                            Text("Contact Privacy Team")
-                                .foregroundColor(.primary)
-                        }
-                    }
-                    
-                    Button(action: {
-                        if let url = URL(string: "mailto:support@timetrack.app?subject=Terms%20Question") {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        HStack {
-                            Image(systemName: "questionmark.circle")
-                                .foregroundColor(.blue)
-                            Text("Contact Support")
-                                .foregroundColor(.primary)
-                        }
-                    }
-                } header: {
-                    Text("Questions?")
-                } footer: {
-                    Text("If you have questions about these documents or our policies, we're here to help.")
-                }
-            }
-            .navigationTitle("Legal & Privacy")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
-                        dismiss()
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(AppTheme.accent)
                     }
                 }
+                .toolbarBackground(AppTheme.background, for: .navigationBar)
+                .toolbarBackground(.visible, for: .navigationBar)
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())

--- a/packages/ios-app/Timetrack/Timetrack/Views/LoginView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/LoginView.swift
@@ -11,102 +11,131 @@ struct LoginView: View {
 
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
-                // Header
-                VStack(spacing: 16) {
-                    Image(systemName: "clock.circle.fill")
-                        .font(.system(size: 60))
-                        .foregroundColor(.blue)
+            ZStack {
+                // Dark background
+                AppTheme.background
+                    .ignoresSafeArea()
 
-                    Text("Sign in to TimeTrack")
-                        .font(.title)
-                        .fontWeight(.bold)
-                        .foregroundColor(.primary)
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // Header
+                        VStack(spacing: AppTheme.spacingLG) {
+                            // App icon with gradient
+                            ZStack {
+                                Circle()
+                                    .fill(AppTheme.accentGradient)
+                                    .frame(width: 80, height: 80)
+                                    .shadow(color: AppTheme.accent.opacity(0.4), radius: 15, x: 0, y: 8)
 
-                    Text("Track your time efficiently")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.bottom, 40)
-
-                // Login Form
-                VStack(spacing: 20) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Email")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-
-                        TextField("Enter your email", text: $email)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-                            .textInputAutocapitalization(.never)
-                            .keyboardType(.emailAddress)
-                    }
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Password")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-
-                        SecureField("Enter your password", text: $password)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-                    }
-
-                    if let errorMessage = authViewModel.errorMessage {
-                        Text(errorMessage)
-                            .foregroundColor(.red)
-                            .font(.caption)
-                            .multilineTextAlignment(.center)
-                    }
-
-                    Button(action: {
-                        Task {
-                            await authViewModel.login(email: email, password: password)
-                        }
-                    }) {
-                        HStack {
-                            if authViewModel.isLoading {
-                                ProgressView()
-                                    .scaleEffect(0.8)
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                Image(systemName: "clock.fill")
+                                    .font(.system(size: 36, weight: .medium))
+                                    .foregroundColor(.white)
                             }
-                            Text(authViewModel.isLoading ? "Signing in..." : "Sign In")
-                                .fontWeight(.semibold)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                    }
-                    .disabled(authViewModel.isLoading || email.isEmpty || password.isEmpty)
 
-                    HStack {
-                        Button("Forgot password?") {
-                            showingForgotPassword = true
-                        }
-                        .font(.footnote)
-                        .foregroundColor(.blue)
-                        
-                        Spacer()
-                    }
-                    .padding(.top, 10)
+                            VStack(spacing: AppTheme.spacingSM) {
+                                Text("Welcome Back")
+                                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                                    .foregroundColor(AppTheme.primary)
 
-                    HStack {
-                        Text("Don't have an account?")
-                            .foregroundColor(.secondary)
-
-                        Button("Sign up") {
-                            showingRegister = true
+                                Text("Sign in to continue tracking")
+                                    .font(.system(size: 15))
+                                    .foregroundColor(AppTheme.secondary)
+                            }
                         }
-                        .foregroundColor(.blue)
+                        .padding(.top, 60)
+                        .padding(.bottom, 40)
+
+                        // Login Form Card
+                        VStack(spacing: AppTheme.spacingXL) {
+                            VStack(spacing: AppTheme.spacingLG) {
+                                PremiumInputField(
+                                    title: "Email",
+                                    placeholder: "Enter your email",
+                                    text: $email,
+                                    keyboardType: .emailAddress,
+                                    autocapitalization: .never
+                                )
+
+                                PremiumInputField(
+                                    title: "Password",
+                                    placeholder: "Enter your password",
+                                    text: $password,
+                                    isSecure: true
+                                )
+                            }
+                            .onSubmit {
+                                if !email.isEmpty && !password.isEmpty && !authViewModel.isLoading {
+                                    Task {
+                                        await authViewModel.login(email: email, password: password)
+                                    }
+                                }
+                            }
+
+                            if let errorMessage = authViewModel.errorMessage {
+                                Text(errorMessage)
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(AppTheme.error)
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal)
+                            }
+
+                            // Sign In Button
+                            Button(action: {
+                                Task {
+                                    await authViewModel.login(email: email, password: password)
+                                }
+                            }) {
+                                HStack(spacing: AppTheme.spacingSM) {
+                                    if authViewModel.isLoading {
+                                        ProgressView()
+                                            .scaleEffect(0.8)
+                                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    }
+                                    Text(authViewModel.isLoading ? "Signing in..." : "Sign In")
+                                }
+                            }
+                            .buttonStyle(PremiumPrimaryButtonStyle())
+                            .disabled(authViewModel.isLoading || email.isEmpty || password.isEmpty)
+                            .opacity((authViewModel.isLoading || email.isEmpty || password.isEmpty) ? 0.6 : 1)
+
+                            // Forgot password link
+                            HStack {
+                                Button("Forgot password?") {
+                                    showingForgotPassword = true
+                                }
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(AppTheme.accent)
+
+                                Spacer()
+                            }
+                        }
+                        .padding(AppTheme.spacingXL)
+                        .background(AppTheme.cardBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusLG))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppTheme.radiusLG)
+                                .stroke(AppTheme.border, lineWidth: 1)
+                        )
+                        .padding(.horizontal, AppTheme.spacingLG)
+
+                        // Sign up link
+                        HStack(spacing: AppTheme.spacingXS) {
+                            Text("Don't have an account?")
+                                .font(.system(size: 14))
+                                .foregroundColor(AppTheme.secondary)
+
+                            Button("Sign up") {
+                                showingRegister = true
+                            }
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(AppTheme.accent)
+                        }
+                        .padding(.top, AppTheme.spacingXL)
                     }
-                    .padding(.top, 10)
+                    .padding(.bottom, 40)
                 }
-                .padding(.horizontal, 40)
-                .frame(maxWidth: 400)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(UIColor.systemBackground))
+            .navigationBarHidden(true)
             .onAppear {
                 authViewModel.clearError()
             }

--- a/packages/ios-app/Timetrack/Timetrack/Views/RegisterView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/RegisterView.swift
@@ -12,118 +12,131 @@ struct RegisterView: View {
 
     var body: some View {
         NavigationView {
-            ScrollView {
-                VStack(spacing: 0) {
-                    // Header
-                    VStack(spacing: 16) {
-                        Image(systemName: "person.crop.circle.fill.badge.plus")
-                            .font(.system(size: 60))
-                            .foregroundColor(.blue)
+            ZStack {
+                // Dark background
+                AppTheme.background
+                    .ignoresSafeArea()
 
-                        Text("Create your account")
-                            .font(.title)
-                            .fontWeight(.bold)
-                            .foregroundColor(.primary)
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // Header
+                        VStack(spacing: AppTheme.spacingLG) {
+                            // App icon with gradient
+                            ZStack {
+                                Circle()
+                                    .fill(AppTheme.accentGradient)
+                                    .frame(width: 80, height: 80)
+                                    .shadow(color: AppTheme.accent.opacity(0.4), radius: 15, x: 0, y: 8)
 
-                        Text("Start tracking your time today")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.bottom, 40)
-                    .padding(.top, 20)
-
-                    // Register Form
-                    VStack(spacing: 20) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Full Name")
-                                .font(.headline)
-                                .foregroundColor(.primary)
-
-                            TextField("Enter your full name", text: $name)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .textInputAutocapitalization(.words)
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Email Address")
-                                .font(.headline)
-                                .foregroundColor(.primary)
-
-                            TextField("Enter your email", text: $email)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .textInputAutocapitalization(.never)
-                                .keyboardType(.emailAddress)
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Password")
-                                .font(.headline)
-                                .foregroundColor(.primary)
-
-                            SecureField("Enter your password", text: $password)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Confirm Password")
-                                .font(.headline)
-                                .foregroundColor(.primary)
-
-                            SecureField("Confirm your password", text: $confirmPassword)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .border(showingPasswordMismatchError ? Color.red : Color.clear, width: 1)
-                        }
-
-                        if showingPasswordMismatchError {
-                            Text("Passwords do not match")
-                                .foregroundColor(.red)
-                                .font(.caption)
-                        }
-
-                        if let errorMessage = authViewModel.errorMessage {
-                            Text(errorMessage)
-                                .foregroundColor(.red)
-                                .font(.caption)
-                                .multilineTextAlignment(.center)
-                        }
-
-                        Button(action: {
-                            register()
-                        }) {
-                            HStack {
-                                if authViewModel.isLoading {
-                                    ProgressView()
-                                        .scaleEffect(0.8)
-                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                }
-                                Text(authViewModel.isLoading ? "Creating Account..." : "Create Account")
-                                    .fontWeight(.semibold)
+                                Image(systemName: "person.crop.circle.badge.plus")
+                                    .font(.system(size: 36, weight: .medium))
+                                    .foregroundColor(.white)
                             }
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(isFormValid ? Color.blue : Color.gray)
-                            .foregroundColor(.white)
-                            .cornerRadius(8)
-                        }
-                        .disabled(!isFormValid || authViewModel.isLoading)
 
-                        HStack {
+                            VStack(spacing: AppTheme.spacingSM) {
+                                Text("Create Account")
+                                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                                    .foregroundColor(AppTheme.primary)
+
+                                Text("Start tracking your time today")
+                                    .font(.system(size: 15))
+                                    .foregroundColor(AppTheme.secondary)
+                            }
+                        }
+                        .padding(.top, 40)
+                        .padding(.bottom, 32)
+
+                        // Register Form Card
+                        VStack(spacing: AppTheme.spacingXL) {
+                            VStack(spacing: AppTheme.spacingLG) {
+                                PremiumInputField(
+                                    title: "Full Name",
+                                    placeholder: "Enter your full name",
+                                    text: $name,
+                                    autocapitalization: .words
+                                )
+
+                                PremiumInputField(
+                                    title: "Email",
+                                    placeholder: "Enter your email",
+                                    text: $email,
+                                    keyboardType: .emailAddress,
+                                    autocapitalization: .never
+                                )
+
+                                PremiumInputField(
+                                    title: "Password",
+                                    placeholder: "Enter your password",
+                                    text: $password,
+                                    isSecure: true
+                                )
+
+                                PremiumInputField(
+                                    title: "Confirm Password",
+                                    placeholder: "Confirm your password",
+                                    text: $confirmPassword,
+                                    isSecure: true,
+                                    errorMessage: showingPasswordMismatchError ? "Passwords do not match" : nil
+                                )
+                            }
+                            .onSubmit {
+                                if isFormValid && !authViewModel.isLoading {
+                                    register()
+                                }
+                            }
+
+                            if let errorMessage = authViewModel.errorMessage {
+                                Text(errorMessage)
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(AppTheme.error)
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal)
+                            }
+
+                            // Create Account Button
+                            Button(action: {
+                                register()
+                            }) {
+                                HStack(spacing: AppTheme.spacingSM) {
+                                    if authViewModel.isLoading {
+                                        ProgressView()
+                                            .scaleEffect(0.8)
+                                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    }
+                                    Text(authViewModel.isLoading ? "Creating Account..." : "Create Account")
+                                }
+                            }
+                            .buttonStyle(PremiumPrimaryButtonStyle())
+                            .disabled(!isFormValid || authViewModel.isLoading)
+                            .opacity((!isFormValid || authViewModel.isLoading) ? 0.6 : 1)
+                        }
+                        .padding(AppTheme.spacingXL)
+                        .background(AppTheme.cardBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusLG))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppTheme.radiusLG)
+                                .stroke(AppTheme.border, lineWidth: 1)
+                        )
+                        .padding(.horizontal, AppTheme.spacingLG)
+
+                        // Sign in link
+                        HStack(spacing: AppTheme.spacingXS) {
                             Text("Already have an account?")
-                                .foregroundColor(.secondary)
+                                .font(.system(size: 14))
+                                .foregroundColor(AppTheme.secondary)
 
                             Button("Sign in") {
                                 showingRegister = false
                             }
-                            .foregroundColor(.blue)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(AppTheme.accent)
                         }
-                        .padding(.top, 10)
+                        .padding(.top, AppTheme.spacingXL)
                     }
-                    .padding(.horizontal, 40)
-                    .frame(maxWidth: 400)
+                    .padding(.bottom, 40)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(UIColor.systemBackground))
+            .navigationBarHidden(true)
             .onAppear {
                 authViewModel.clearError()
             }

--- a/packages/ios-app/Timetrack/Timetrack/Views/SettingsView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/SettingsView.swift
@@ -29,29 +29,33 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                List {
-                    // User Profile Section
-                    if let user = authViewModel.currentUser {
-                        profileSection(user: user)
+                // Dark background
+                AppTheme.background
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: AppTheme.spacingLG) {
+                        // User Profile Section
+                        if let user = authViewModel.currentUser {
+                            profileSection(user: user)
+                        }
+
+                        // Timer Preferences
+                        timerPreferencesSection
+
+                        // Data Management
+                        dataManagementSection
+
+                        // App Information
+                        appInformationSection
+
+                        // Legal & Privacy
+                        legalSection
+
+                        // Account Actions
+                        accountActionsSection
                     }
-
-                    // Timer Preferences
-                    timerPreferencesSection
-
-                    // Notifications (TODO: Backend support needed)
-                    // notificationsSection
-
-                    // Data Management
-                    dataManagementSection
-
-                    // App Information
-                    appInformationSection
-
-                    // Legal & Privacy
-                    legalSection
-
-                    // Account Actions
-                    accountActionsSection
+                    .padding(AppTheme.spacingLG)
                 }
                 .navigationTitle("Settings")
                 .navigationBarTitleDisplayMode(.inline)
@@ -66,7 +70,8 @@ struct SettingsView: View {
                                 dismiss()
                             }
                         }
-                        .fontWeight(hasUnsavedChanges ? .semibold : .regular)
+                        .font(.system(size: 15, weight: hasUnsavedChanges ? .semibold : .regular))
+                        .foregroundColor(AppTheme.accent)
                     }
                 }
                 .disabled(isSaving)
@@ -74,17 +79,26 @@ struct SettingsView: View {
 
                 // Loading overlay
                 if isSaving {
-                    Color.black.opacity(0.3)
+                    Color.black.opacity(0.5)
                         .ignoresSafeArea()
                         .overlay {
-                            ProgressView("Saving...")
-                                .padding()
-                                .background(Color(.systemBackground))
-                                .cornerRadius(10)
-                                .shadow(radius: 5)
+                            VStack(spacing: AppTheme.spacingMD) {
+                                ProgressView()
+                                    .scaleEffect(1.2)
+                                    .progressViewStyle(CircularProgressViewStyle(tint: AppTheme.accent))
+
+                                Text("Saving...")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundColor(AppTheme.primary)
+                            }
+                            .padding(AppTheme.spacingXL)
+                            .background(AppTheme.cardBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
                         }
                 }
             }
+            .toolbarBackground(AppTheme.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {
@@ -146,33 +160,41 @@ struct SettingsView: View {
 
     // MARK: - Profile Section
     private func profileSection(user: User) -> some View {
-        Section {
-            HStack {
-                Circle()
-                    .fill(Color.blue.gradient)
-                    .frame(width: 60, height: 60)
-                    .overlay {
-                        Text(String(user.name.first?.uppercased() ?? "U"))
-                            .font(.title2)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.white)
-                    }
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text("Profile")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
 
-                VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: AppTheme.spacingMD) {
+                // Avatar
+                ZStack {
+                    Circle()
+                        .fill(AppTheme.accentGradient)
+                        .frame(width: 56, height: 56)
+
+                    Text(String(user.name.first?.uppercased() ?? "U"))
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+
+                VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
                     Text(user.name)
-                        .font(.headline)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(AppTheme.primary)
+
                     Text(user.email)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .font(.system(size: 14))
+                        .foregroundColor(AppTheme.secondary)
 
                     if let rate = user.defaultHourlyRate {
-                        Text("$\(rate, specifier: "%.2f")/hour")
-                            .font(.caption)
-                            .padding(.horizontal, 8)
+                        Text(String(format: "$%.2f/hour", rate))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(AppTheme.earnings)
+                            .padding(.horizontal, AppTheme.spacingSM)
                             .padding(.vertical, 2)
-                            .background(Color.green.opacity(0.2))
-                            .foregroundColor(.green)
-                            .cornerRadius(4)
+                            .background(AppTheme.earnings.opacity(0.15))
+                            .clipShape(Capsule())
                     }
                 }
 
@@ -181,308 +203,339 @@ struct SettingsView: View {
                 Button("Edit") {
                     showingProfileEdit = true
                 }
-                .foregroundColor(.blue)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(AppTheme.accent)
             }
-            .padding(.vertical, 8)
-        } header: {
-            Text("Profile")
+            .padding(AppTheme.spacingLG)
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .stroke(AppTheme.border, lineWidth: 1)
+            )
         }
     }
 
     // MARK: - Timer Preferences Section
     private var timerPreferencesSection: some View {
-        Section {
-            HStack {
-                Image(systemName: "clock")
-                    .foregroundColor(.blue)
-                    .frame(width: 24)
-
-                VStack(alignment: .leading) {
-                    Text("Default Hourly Rate")
-                    if !editedDefaultHourlyRate.isEmpty {
-                        Text("$\(editedDefaultHourlyRate)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                Spacer()
-
-                TextField("0.00", text: $editedDefaultHourlyRate)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .keyboardType(.decimalPad)
-                    .frame(width: 80)
-            }
-
-            // TODO: Add backend support for reminder intervals to notify users periodically while timer is running
-            /*
-            HStack {
-                Image(systemName: "bell")
-                    .foregroundColor(.orange)
-                    .frame(width: 24)
-
-                VStack(alignment: .leading) {
-                    Text("Reminder Interval")
-                    Text("Every \(reminderInterval) minutes")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-
-                Spacer()
-
-                Picker("Minutes", selection: $reminderInterval) {
-                    Text("15 min").tag(15)
-                    Text("30 min").tag(30)
-                    Text("60 min").tag(60)
-                    Text("Off").tag(0)
-                }
-                .pickerStyle(MenuPickerStyle())
-            }
-            */
-
-            // TODO: Add automatic timer start feature when opening app or selecting project
-            /*
-            Toggle(isOn: $autoStartTimer) {
-                HStack {
-                    Image(systemName: "play.circle")
-                        .foregroundColor(.green)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading) {
-                        Text("Auto-start Timer")
-                        Text("Start timer when opening app")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-            }
-            */
-
-            HStack {
-                Image(systemName: "moon.zzz")
-                    .foregroundColor(.indigo)
-                    .frame(width: 24)
-
-                VStack(alignment: .leading) {
-                    Text("Idle Timeout")
-                    Text("Auto-stop timer after inactivity")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-
-                Spacer()
-
-                TextField("10", text: $editedIdleTimeoutMinutes)
-                    .frame(width: 60)
-                    .multilineTextAlignment(.trailing)
-                    .textFieldStyle(.roundedBorder)
-                    .keyboardType(.numberPad)
-
-                Text("min")
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-            }
-        } header: {
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
             Text("Timer Settings")
-        } footer: {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Timer will automatically stop when app is backgrounded for more than the idle timeout duration (1-120 minutes).")
-                if hasUnsavedChanges {
-                    Text("Tap Done to save your changes.")
-                        .foregroundColor(.orange)
-                        .font(.caption)
-                }
-            }
-        }
-    }
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
 
-    // MARK: - Notifications Section (TODO: Backend support needed)
-    private var notificationsSection: some View {
-        Section {
-            // TODO: Integrate with iOS push notifications for timer reminders and important updates
-            Toggle(isOn: $showNotifications) {
+            VStack(spacing: 0) {
+                // Default Hourly Rate
                 HStack {
-                    Image(systemName: "bell.badge")
-                        .foregroundColor(.red)
-                        .frame(width: 24)
+                    HStack(spacing: AppTheme.spacingMD) {
+                        Image(systemName: "dollarsign.circle")
+                            .font(.system(size: 18))
+                            .foregroundColor(AppTheme.earnings)
 
-                    VStack(alignment: .leading) {
-                        Text("Notifications")
-                        Text("Timer reminders and updates")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Default Hourly Rate")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(AppTheme.primary)
+
+                            if !editedDefaultHourlyRate.isEmpty {
+                                Text("$\(editedDefaultHourlyRate)")
+                                    .font(.system(size: 12))
+                                    .foregroundColor(AppTheme.secondary)
+                            }
+                        }
+                    }
+
+                    Spacer()
+
+                    TextField("0.00", text: $editedDefaultHourlyRate)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(AppTheme.primary)
+                        .multilineTextAlignment(.trailing)
+                        .keyboardType(.decimalPad)
+                        .frame(width: 70)
+                        .padding(AppTheme.spacingSM)
+                        .background(AppTheme.backgroundElevated)
+                        .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+                }
+                .padding(AppTheme.spacingMD)
+
+                Divider()
+                    .background(AppTheme.border)
+
+                // Idle Timeout
+                HStack {
+                    HStack(spacing: AppTheme.spacingMD) {
+                        Image(systemName: "moon.zzz")
+                            .font(.system(size: 18))
+                            .foregroundColor(AppTheme.accent)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Idle Timeout")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(AppTheme.primary)
+
+                            Text("Auto-stop after inactivity")
+                                .font(.system(size: 12))
+                                .foregroundColor(AppTheme.secondary)
+                        }
+                    }
+
+                    Spacer()
+
+                    HStack(spacing: AppTheme.spacingXS) {
+                        TextField("10", text: $editedIdleTimeoutMinutes)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.primary)
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.numberPad)
+                            .frame(width: 50)
+                            .padding(AppTheme.spacingSM)
+                            .background(AppTheme.backgroundElevated)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+
+                        Text("min")
+                            .font(.system(size: 13))
+                            .foregroundColor(AppTheme.tertiary)
                     }
                 }
+                .padding(AppTheme.spacingMD)
             }
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .stroke(AppTheme.border, lineWidth: 1)
+            )
 
-            // TODO: Add sound effects for timer start/stop events for better user feedback
-            Toggle(isOn: $soundEnabled) {
-                HStack {
-                    Image(systemName: "speaker.wave.2")
-                        .foregroundColor(.purple)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading) {
-                        Text("Sound Effects")
-                        Text("Timer start/stop sounds")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
+            if hasUnsavedChanges {
+                Text("Tap Done to save your changes")
+                    .font(.system(size: 12))
+                    .foregroundColor(AppTheme.warning)
+            } else {
+                Text("Timer will auto-stop when app is backgrounded for more than the idle timeout (1-120 min)")
+                    .font(.system(size: 12))
+                    .foregroundColor(AppTheme.tertiary)
             }
-            .disabled(!showNotifications)
-        } header: {
-            Text("Notifications")
-        } footer: {
-            Text("You can manage notification permissions in iOS Settings.")
         }
     }
 
     // MARK: - Data Management Section
     private var dataManagementSection: some View {
-        Section {
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text("Data Management")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
+
             Button(action: {
                 showingExportData = true
             }) {
                 HStack {
-                    Image(systemName: "square.and.arrow.up")
-                        .foregroundColor(.blue)
-                        .frame(width: 24)
+                    HStack(spacing: AppTheme.spacingMD) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 18))
+                            .foregroundColor(AppTheme.accent)
 
-                    VStack(alignment: .leading) {
-                        Text("Export Data")
-                            .foregroundColor(.primary)
-                        Text("Download your time tracking data")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Export Data")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(AppTheme.primary)
+
+                            Text("Download your time tracking data")
+                                .font(.system(size: 12))
+                                .foregroundColor(AppTheme.secondary)
+                        }
                     }
 
                     Spacer()
 
                     Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(AppTheme.tertiary)
                 }
+                .padding(AppTheme.spacingMD)
+                .background(AppTheme.cardBackground)
+                .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                        .stroke(AppTheme.border, lineWidth: 1)
+                )
             }
-
-            // TODO: Implement automatic data sync across devices using CloudKit or similar
-            /*
-            Button(action: {
-                // TODO: Implement data sync
-            }) {
-                HStack {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundColor(.green)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading) {
-                        Text("Sync Data")
-                            .foregroundColor(.primary)
-                        Text("Sync with other devices")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            */
-        } header: {
-            Text("Data Management")
         }
     }
 
     // MARK: - App Information Section
     private var appInformationSection: some View {
-        Section {
-            HStack {
-                Text("Version")
-                Spacer()
-                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
-                    .foregroundColor(.secondary)
-            }
-
-            HStack {
-                Text("Build")
-                Spacer()
-                Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
-                    .foregroundColor(.secondary)
-            }
-
-            Button(action: {
-                if let url = URL(string: "https://apps.apple.com/app/timetrack/id[APP_ID]") {
-                    UIApplication.shared.open(url)
-                }
-            }) {
-                HStack {
-                    Text("Rate TimeTrack")
-                        .foregroundColor(.primary)
-                    Spacer()
-                    Image(systemName: "star")
-                        .foregroundColor(.orange)
-                }
-            }
-
-            Button(action: {
-                if let url = URL(string: "mailto:support@timetrack.app?subject=Feedback") {
-                    UIApplication.shared.open(url)
-                }
-            }) {
-                HStack {
-                    Text("Send Feedback")
-                        .foregroundColor(.primary)
-                    Spacer()
-                    Image(systemName: "envelope")
-                        .foregroundColor(.blue)
-                }
-            }
-        } header: {
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
             Text("About TimeTrack")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
+
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Version")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(AppTheme.primary)
+
+                    Spacer()
+
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                        .font(.system(size: 14))
+                        .foregroundColor(AppTheme.secondary)
+                }
+                .padding(AppTheme.spacingMD)
+
+                Divider()
+                    .background(AppTheme.border)
+
+                HStack {
+                    Text("Build")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(AppTheme.primary)
+
+                    Spacer()
+
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+                        .font(.system(size: 14))
+                        .foregroundColor(AppTheme.secondary)
+                }
+                .padding(AppTheme.spacingMD)
+
+                Divider()
+                    .background(AppTheme.border)
+
+                Button(action: {
+                    if let url = URL(string: "https://apps.apple.com/app/timetrack/id[APP_ID]") {
+                        UIApplication.shared.open(url)
+                    }
+                }) {
+                    HStack {
+                        Text("Rate TimeTrack")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.primary)
+
+                        Spacer()
+
+                        Image(systemName: "star")
+                            .font(.system(size: 14))
+                            .foregroundColor(AppTheme.warning)
+                    }
+                    .padding(AppTheme.spacingMD)
+                }
+
+                Divider()
+                    .background(AppTheme.border)
+
+                Button(action: {
+                    if let url = URL(string: "mailto:support@timetrack.app?subject=Feedback") {
+                        UIApplication.shared.open(url)
+                    }
+                }) {
+                    HStack {
+                        Text("Send Feedback")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.primary)
+
+                        Spacer()
+
+                        Image(systemName: "envelope")
+                            .font(.system(size: 14))
+                            .foregroundColor(AppTheme.accent)
+                    }
+                    .padding(AppTheme.spacingMD)
+                }
+            }
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .stroke(AppTheme.border, lineWidth: 1)
+            )
         }
     }
 
     // MARK: - Legal Section
     private var legalSection: some View {
-        Section {
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+            Text("Legal")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
+
             Button(action: {
                 showingLegalDocuments = true
             }) {
                 HStack {
                     Text("Privacy & Legal")
-                        .foregroundColor(.primary)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(AppTheme.primary)
 
                     Spacer()
 
                     Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(AppTheme.tertiary)
                 }
+                .padding(AppTheme.spacingMD)
+                .background(AppTheme.cardBackground)
+                .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                        .stroke(AppTheme.border, lineWidth: 1)
+                )
             }
-        } header: {
-            Text("Legal")
         }
     }
 
     // MARK: - Account Actions Section
     private var accountActionsSection: some View {
-        Section {
-            Button("Sign Out") {
-                showingLogoutAlert = true
-            }
-            .foregroundColor(.red)
-
-            Button("Delete Account") {
-                showingDeleteAccountAlert = true
-            }
-            .foregroundColor(.red)
-        } header: {
+        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
             Text("Account")
-        } footer: {
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.secondary)
+                .textCase(.uppercase)
+
+            VStack(spacing: 0) {
+                Button(action: {
+                    showingLogoutAlert = true
+                }) {
+                    HStack {
+                        Text("Sign Out")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.error)
+
+                        Spacer()
+                    }
+                    .padding(AppTheme.spacingMD)
+                }
+
+                Divider()
+                    .background(AppTheme.border)
+
+                Button(action: {
+                    showingDeleteAccountAlert = true
+                }) {
+                    HStack {
+                        Text("Delete Account")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(AppTheme.error)
+
+                        Spacer()
+                    }
+                    .padding(AppTheme.spacingMD)
+                }
+            }
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .stroke(AppTheme.border, lineWidth: 1)
+            )
+
             Text("Account deletion is permanent and cannot be undone.")
+                .font(.system(size: 12))
+                .foregroundColor(AppTheme.tertiary)
         }
     }
 
@@ -606,60 +659,111 @@ struct ProfileEditView: View {
 
     var body: some View {
         NavigationView {
-            Form {
-                Section {
-                    TextField("Full Name", text: $name)
-                        .onChange(of: name) { _ in hasUnsavedChanges = true }
+            ZStack {
+                AppTheme.background
+                    .ignoresSafeArea()
 
-                    TextField("Email", text: $email)
-                        .keyboardType(.emailAddress)
-                        .autocapitalization(.none)
-                        .onChange(of: email) { _ in hasUnsavedChanges = true }
+                ScrollView {
+                    VStack(spacing: AppTheme.spacingLG) {
+                        VStack(alignment: .leading, spacing: AppTheme.spacingMD) {
+                            Text("Profile Information")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.secondary)
+                                .textCase(.uppercase)
 
-                    HStack {
-                        Text("Default Hourly Rate")
-                        TextField("$0.00", text: $defaultHourlyRate)
-                            .keyboardType(.decimalPad)
-                            .multilineTextAlignment(.trailing)
-                            .onChange(of: defaultHourlyRate) { _ in hasUnsavedChanges = true }
-                    }
-                } header: {
-                    Text("Profile Information")
-                } footer: {
-                    Text("Your email is used for account authentication and important notifications.")
-                }
+                            VStack(spacing: AppTheme.spacingLG) {
+                                PremiumInputField(
+                                    title: "Full Name",
+                                    placeholder: "Enter your name",
+                                    text: $name
+                                )
 
-                if let errorMessage = errorMessage {
-                    Text(errorMessage)
-                        .foregroundColor(.red)
-                        .font(.caption)
-                }
-            }
-            .navigationTitle("Edit Profile")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
+                                PremiumInputField(
+                                    title: "Email",
+                                    placeholder: "Enter your email",
+                                    text: $email,
+                                    keyboardType: .emailAddress,
+                                    autocapitalization: .never
+                                )
 
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Save") {
-                        Task {
-                            await saveProfile()
+                                VStack(alignment: .leading, spacing: AppTheme.spacingSM) {
+                                    Text("Default Hourly Rate")
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .foregroundColor(AppTheme.primary)
+
+                                    HStack {
+                                        Text("$")
+                                            .font(.system(size: 14, weight: .medium))
+                                            .foregroundColor(AppTheme.secondary)
+
+                                        TextField("0.00", text: $defaultHourlyRate)
+                                            .font(.system(size: 14, weight: .medium))
+                                            .foregroundColor(AppTheme.primary)
+                                            .keyboardType(.decimalPad)
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                    .background(AppTheme.cardBackground)
+                                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: AppTheme.radiusSM)
+                                            .stroke(AppTheme.border, lineWidth: 1)
+                                    )
+                                }
+                            }
+                            .padding(AppTheme.spacingLG)
+                            .background(AppTheme.cardBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                                    .stroke(AppTheme.border, lineWidth: 1)
+                            )
+
+                            Text("Your email is used for account authentication and important notifications.")
+                                .font(.system(size: 12))
+                                .foregroundColor(AppTheme.tertiary)
+                        }
+
+                        if let errorMessage = errorMessage {
+                            Text(errorMessage)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(AppTheme.error)
                         }
                     }
-                    .disabled(isLoading || !hasUnsavedChanges || name.isEmpty || email.isEmpty)
-                    .fontWeight(hasUnsavedChanges ? .semibold : .regular)
+                    .padding(AppTheme.spacingLG)
                 }
+                .navigationTitle("Edit Profile")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") {
+                            dismiss()
+                        }
+                        .foregroundColor(AppTheme.secondary)
+                    }
+
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Save") {
+                            Task {
+                                await saveProfile()
+                            }
+                        }
+                        .disabled(isLoading || !hasUnsavedChanges || name.isEmpty || email.isEmpty)
+                        .font(.system(size: 15, weight: hasUnsavedChanges ? .semibold : .regular))
+                        .foregroundColor(AppTheme.accent)
+                    }
+                }
+                .disabled(isLoading)
+                .toolbarBackground(AppTheme.background, for: .navigationBar)
+                .toolbarBackground(.visible, for: .navigationBar)
             }
-            .disabled(isLoading)
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {
             loadUserData()
         }
+        .onChange(of: name) { _ in hasUnsavedChanges = true }
+        .onChange(of: email) { _ in hasUnsavedChanges = true }
+        .onChange(of: defaultHourlyRate) { _ in hasUnsavedChanges = true }
     }
 
     private func loadUserData() {

--- a/packages/ios-app/Timetrack/Timetrack/Views/SharedComponents.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/SharedComponents.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - Shared UI Components
 
-// Shared project/task display component
+/// Shared project/task display component
 struct ProjectTaskDisplayView: View {
     @EnvironmentObject var timerViewModel: TimerViewModel
     let entry: TimeEntry
@@ -13,75 +13,264 @@ struct ProjectTaskDisplayView: View {
     }
 
     var body: some View {
-        HStack {
-            // Project indicator and name
+        HStack(spacing: style == .compact ? AppTheme.spacingSM : AppTheme.spacingSM) {
+            // Project color indicator
             Circle()
                 .fill(timerViewModel.getProjectColor(for: entry))
                 .frame(width: style == .compact ? 6 : 8, height: style == .compact ? 6 : 8)
 
             Text(timerViewModel.getProjectName(for: entry))
-                .font(style == .compact ? .system(size: 14, weight: .medium) : .headline)
+                .font(style == .compact ? .system(size: 13, weight: .semibold) : .system(size: 14, weight: .semibold))
+                .foregroundColor(AppTheme.primary)
                 .lineLimit(1)
 
             if let task = entry.task {
-                Text("• \(task.name)")
-                    .font(style == .compact ? .system(size: 12) : .subheadline)
-                    .foregroundColor(.secondary)
+                Text(task.name)
+                    .font(style == .compact ? .system(size: 12, weight: .medium) : .system(size: 13, weight: .medium))
+                    .foregroundColor(AppTheme.tertiary)
                     .lineLimit(1)
             }
         }
     }
 }
 
-// Compact earnings display
+/// Compact earnings display
 struct CompactEarningsView: View {
     let earnings: DashboardEarnings?
     let showCurrentTimer: Bool
     let currentTimerEarnings: Double?
 
     var body: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: AppTheme.spacingSM) {
             // Show live current timer earnings if timer is running
             if showCurrentTimer, let liveEarnings = currentTimerEarnings {
-                HStack {
-                    Text("Current Timer:")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text("$\(liveEarnings, specifier: "%.2f")")
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .foregroundColor(.green)
-                }
+                CompactEarningsRow(
+                    label: "Current Timer",
+                    value: String(format: "$%.2f", liveEarnings),
+                    valueColor: AppTheme.earnings,
+                    isHighlighted: true
+                )
             }
 
             if let earnings = earnings {
-                HStack {
-                    Text("Today:")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text("$\(earnings.today.earnings, specifier: "%.2f")")
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .foregroundColor(.primary)
-                }
+                CompactEarningsRow(
+                    label: "Today",
+                    value: String(format: "$%.2f", earnings.today.earnings)
+                )
 
-                HStack {
-                    Text("This Week:")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text("$\(earnings.thisWeek.earnings, specifier: "%.2f")")
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .foregroundColor(.primary)
-                }
+                CompactEarningsRow(
+                    label: "This Week",
+                    value: String(format: "$%.2f", earnings.thisWeek.earnings)
+                )
             } else {
                 Text("Unable to load earnings")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+                    .foregroundColor(AppTheme.tertiary)
             }
         }
+    }
+}
+
+/// Single earnings row for compact display
+struct CompactEarningsRow: View {
+    let label: String
+    let value: String
+    var valueColor: Color = AppTheme.primary
+    var isHighlighted: Bool = false
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 12, weight: isHighlighted ? .medium : .regular))
+                .foregroundColor(isHighlighted ? AppTheme.primary : AppTheme.secondary)
+
+            Spacer()
+
+            Text(value)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(valueColor)
+        }
+    }
+}
+
+// MARK: - Premium Button Styles
+
+/// Primary gradient button style
+struct PremiumPrimaryButtonStyle: ButtonStyle {
+    var gradient: LinearGradient = AppTheme.accentGradient
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppTheme.spacingMD)
+            .background(gradient)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .shadow(color: AppTheme.accent.opacity(0.3), radius: 8, x: 0, y: 4)
+            .opacity(configuration.isPressed ? 0.9 : 1.0)
+    }
+}
+
+/// Secondary outline button style
+struct PremiumSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(AppTheme.accent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppTheme.spacingMD)
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .stroke(AppTheme.accent.opacity(0.5), lineWidth: 1)
+            )
+            .opacity(configuration.isPressed ? 0.9 : 1.0)
+    }
+}
+
+// MARK: - Premium Input Components
+
+/// Premium styled text field with floating label support
+struct PremiumInputField: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var isSecure: Bool = false
+    var errorMessage: String? = nil
+    var keyboardType: UIKeyboardType = .default
+    var autocapitalization: TextInputAutocapitalization = .sentences
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.spacingSM) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(AppTheme.primary)
+
+            Group {
+                if isSecure {
+                    SecureField(placeholder, text: $text)
+                        .focused($isFocused)
+                } else {
+                    TextField(placeholder, text: $text)
+                        .focused($isFocused)
+                        .keyboardType(keyboardType)
+                        .textInputAutocapitalization(autocapitalization)
+                }
+            }
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(AppTheme.primary)
+            .padding(AppTheme.spacingMD)
+            .background(AppTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.radiusSM)
+                    .stroke(errorMessage != nil ? AppTheme.error : (isFocused ? AppTheme.accent.opacity(0.5) : AppTheme.border), lineWidth: 1)
+            )
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(AppTheme.error)
+            }
+        }
+    }
+}
+
+// MARK: - Status Indicators
+
+/// Animated live status indicator (pulsing dot only)
+struct LiveIndicator: View {
+    @State private var isAnimating = false
+
+    var body: some View {
+        Circle()
+            .fill(AppTheme.success)
+            .frame(width: 8, height: 8)
+            .opacity(isAnimating ? 0.4 : 1.0)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
+                    isAnimating = true
+                }
+            }
+    }
+}
+
+/// Loading spinner with optional label
+struct PremiumLoadingView: View {
+    var label: String? = nil
+
+    var body: some View {
+        HStack(spacing: AppTheme.spacingSM) {
+            ProgressView()
+                .scaleEffect(0.8)
+                .progressViewStyle(CircularProgressViewStyle(tint: AppTheme.accent))
+
+            if let label = label {
+                Text(label)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(AppTheme.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Cards and Containers
+
+/// Premium card container with optional glow effect
+struct PremiumCard<Content: View>: View {
+    var hasGlow: Bool = false
+    var glowColor: Color = AppTheme.accent
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        ZStack {
+            if hasGlow {
+                RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                    .fill(glowColor.opacity(0.05))
+                    .blur(radius: 15)
+                    .padding(-5)
+            }
+
+            content()
+                .padding(AppTheme.spacingLG)
+                .background(AppTheme.cardBackground)
+                .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.radiusMD)
+                        .stroke(hasGlow ? glowColor.opacity(0.3) : AppTheme.border, lineWidth: 1)
+                )
+        }
+    }
+}
+
+// MARK: - Empty States
+
+/// Premium empty state view
+struct PremiumEmptyState: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(spacing: AppTheme.spacingMD) {
+            Image(systemName: icon)
+                .font(.system(size: 36, weight: .light))
+                .foregroundColor(AppTheme.tertiary)
+
+            Text(title)
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .foregroundColor(AppTheme.primary)
+
+            Text(subtitle)
+                .font(.system(size: 13))
+                .foregroundColor(AppTheme.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, AppTheme.spacing2XL)
     }
 }

--- a/packages/ios-app/Timetrack/Timetrack/Views/TimerView.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Views/TimerView.swift
@@ -6,237 +6,232 @@ struct TimerView: View {
     @State private var selectedTaskId: String = ""
     @State private var description: String = ""
 
-    // Callback functions and state for refresh/settings buttons
-    let onRefresh: () -> Void
-    let onSettings: () -> Void
-    let rotationDegrees: Double
-    let isRefreshing: Bool
-
-    init(onRefresh: @escaping () -> Void = {}, onSettings: @escaping () -> Void = {}, rotationDegrees: Double = 0.0, isRefreshing: Bool = false) {
-        self.onRefresh = onRefresh
-        self.onSettings = onSettings
-        self.rotationDegrees = rotationDegrees
-        self.isRefreshing = isRefreshing
-    }
-
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: AppTheme.spacingLG) {
             // Timer Display or Form
             if timerViewModel.isRunning, let entry = timerViewModel.currentEntry {
-                // Active timer view
-                VStack(spacing: 20) {
-                    // Top section with project/task names and action buttons
-                    HStack {
-                        VStack(alignment: .leading, spacing: 8) {
-                            // Project name
-                            Text(entry.project?.name ?? "No Project")
-                                .font(.title2)
-                                .fontWeight(.bold)
-                                .lineLimit(1)
+                // Active timer view - matching macOS layout
+                VStack(spacing: AppTheme.spacingLG) {
+                    // Project/task names at top
+                    VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
+                        Text(entry.project?.name ?? "No Project")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundColor(AppTheme.primary)
+                            .lineLimit(1)
 
-                            // Task name
-                            Text(entry.task?.name ?? "No Task")
-                                .font(.title3)
-                                .foregroundColor(.secondary)
+                        if let task = entry.task {
+                            Text(task.name)
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundColor(AppTheme.tertiary)
                                 .lineLimit(1)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    // Timer and stop button on same row
+                    HStack(alignment: .center) {
+                        // Timer and earnings stacked
+                        VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
+                            Text(timerViewModel.formattedElapsedTime)
+                                .font(.system(size: 48, weight: .bold, design: .monospaced))
+                                .foregroundColor(AppTheme.primary)
+
+                            if let liveEarnings = timerViewModel.currentTimerLiveEarnings {
+                                Text(String(format: "$%.2f", liveEarnings))
+                                    .font(.system(size: 22, weight: .semibold, design: .rounded))
+                                    .foregroundColor(AppTheme.earnings)
+                            }
                         }
 
                         Spacer()
 
-                        // Action buttons
-                        HStack(spacing: 12) {
-                            Button(action: onRefresh) {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.title3)
-                                    .foregroundColor(.secondary)
+                        // Stop button - circular like macOS
+                        Button(action: {
+                            Task {
+                                await timerViewModel.stopTimer()
                             }
-                            .rotationEffect(.degrees(rotationDegrees))
-                            .disabled(isRefreshing)
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(AppTheme.error)
+                                    .frame(width: 56, height: 56)
 
-                            Button(action: onSettings) {
-                                Image(systemName: "gearshape")
-                                    .font(.title3)
-                                    .foregroundColor(.secondary)
+                                if timerViewModel.isLoading {
+                                    ProgressView()
+                                        .scaleEffect(0.8)
+                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                } else {
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Color.white)
+                                        .frame(width: 20, height: 20)
+                                }
                             }
                         }
+                        .disabled(timerViewModel.isLoading)
                     }
-
-                    // Timer display section
-                    VStack(spacing: 16) {
-                        // Big timer display
-                        Text(timerViewModel.formattedElapsedTime)
-                            .font(.system(size: 42, weight: .bold, design: .monospaced))
-                            .foregroundColor(.primary)
-
-                        // Live earnings if available
-                        if let liveEarnings = timerViewModel.currentTimerLiveEarnings {
-                            Text("$\(liveEarnings, specifier: "%.2f")")
-                                .font(.title)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.green)
-                        }
-
-                        // Description if available
-                        if let desc = entry.description, !desc.isEmpty {
-                            Text(desc)
-                                .font(.body)
-                                .foregroundColor(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
-                    }
-
-                    // Stop button
-                    Button(action: {
-                        Task {
-                            await timerViewModel.stopTimer()
-                        }
-                    }) {
-                        HStack {
-                            if timerViewModel.isLoading {
-                                ProgressView()
-                                    .scaleEffect(0.8)
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                            }
-                            Image(systemName: "stop.fill")
-                            Text(timerViewModel.isLoading ? "Stopping..." : "Stop Timer")
-                                .fontWeight(.semibold)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.red)
-                        .foregroundColor(.white)
-                        .cornerRadius(12)
-                    }
-                    .disabled(timerViewModel.isLoading)
                 }
-                .padding()
 
             } else {
                 // Start timer form
-                VStack(spacing: 20) {
+                VStack(spacing: AppTheme.spacingXL) {
                     // Header
-                    HStack {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Start Timer")
-                                .font(.title2)
-                                .fontWeight(.bold)
+                    VStack(alignment: .leading, spacing: AppTheme.spacingXS) {
+                        Text("Start Timer")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundColor(AppTheme.primary)
 
-                            Text("Track your time")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-
-                        Spacer()
-
-                        // Action buttons
-                        HStack(spacing: 12) {
-                            Button(action: onRefresh) {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.title3)
-                                    .foregroundColor(.secondary)
-                            }
-                            .rotationEffect(.degrees(rotationDegrees))
-                            .disabled(isRefreshing)
-
-                            Button(action: onSettings) {
-                                Image(systemName: "gearshape")
-                                    .font(.title3)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
+                        Text("Track your time")
+                            .font(.system(size: 14))
+                            .foregroundColor(AppTheme.tertiary)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                    VStack(spacing: 16) {
+                    VStack(spacing: AppTheme.spacingMD) {
                         // Project picker
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: AppTheme.spacingSM) {
                             Text("Project")
-                                .font(.headline)
-                                .foregroundColor(.primary)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.primary)
 
-                            Picker("Select Project", selection: $selectedProjectId) {
-                                Text("No Project").tag("")
-                                ForEach(timerViewModel.projects) { project in
-                                    HStack {
-                                        Circle()
-                                            .fill(Color(hex: project.color ?? "#808080") ?? .gray)
-                                            .frame(width: 8, height: 8)
-                                        Text(project.name)
-                                    }
-                                    .tag(project.id)
+                            Menu {
+                                Button("No Project") {
+                                    selectedProjectId = ""
                                 }
+                                ForEach(timerViewModel.projects) { project in
+                                    Button(action: { selectedProjectId = project.id }) {
+                                        HStack {
+                                            Circle()
+                                                .fill(Color(hex: project.color ?? "#808080") ?? .gray)
+                                                .frame(width: 8, height: 8)
+                                            Text(project.name)
+                                        }
+                                    }
+                                }
+                            } label: {
+                                HStack {
+                                    if selectedProjectId.isEmpty {
+                                        Text("Select a project")
+                                            .foregroundColor(AppTheme.tertiary)
+                                    } else if let project = timerViewModel.projects.first(where: { $0.id == selectedProjectId }) {
+                                        HStack(spacing: AppTheme.spacingSM) {
+                                            Circle()
+                                                .fill(Color(hex: project.color ?? "#808080") ?? .gray)
+                                                .frame(width: 8, height: 8)
+                                            Text(project.name)
+                                                .foregroundColor(AppTheme.primary)
+                                        }
+                                    }
+
+                                    Spacer()
+
+                                    Image(systemName: "chevron.down")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(AppTheme.tertiary)
+                                }
+                                .padding(AppTheme.spacingMD)
+                                .background(AppTheme.backgroundElevated)
+                                .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: AppTheme.radiusSM)
+                                        .stroke(AppTheme.border, lineWidth: 1)
+                                )
                             }
-                            .pickerStyle(MenuPickerStyle())
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color(UIColor.secondarySystemBackground))
-                            .cornerRadius(8)
                         }
 
                         // Task picker (only shown if project selected)
                         if !selectedProjectId.isEmpty && !timerViewModel.tasks.isEmpty {
-                            VStack(alignment: .leading, spacing: 8) {
+                            VStack(alignment: .leading, spacing: AppTheme.spacingSM) {
                                 Text("Task (Optional)")
-                                    .font(.headline)
-                                    .foregroundColor(.primary)
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(AppTheme.primary)
 
-                                Picker("Select Task", selection: $selectedTaskId) {
-                                    Text("No Task").tag("")
-                                    ForEach(timerViewModel.tasks) { task in
-                                        Text(task.name).tag(task.id)
+                                Menu {
+                                    Button("No Task") {
+                                        selectedTaskId = ""
                                     }
+                                    ForEach(timerViewModel.tasks) { task in
+                                        Button(task.name) {
+                                            selectedTaskId = task.id
+                                        }
+                                    }
+                                } label: {
+                                    HStack {
+                                        if selectedTaskId.isEmpty {
+                                            Text("Select a task")
+                                                .foregroundColor(AppTheme.tertiary)
+                                        } else if let task = timerViewModel.tasks.first(where: { $0.id == selectedTaskId }) {
+                                            Text(task.name)
+                                                .foregroundColor(AppTheme.primary)
+                                        }
+
+                                        Spacer()
+
+                                        Image(systemName: "chevron.down")
+                                            .font(.system(size: 12, weight: .medium))
+                                            .foregroundColor(AppTheme.tertiary)
+                                    }
+                                    .padding(AppTheme.spacingMD)
+                                    .background(AppTheme.backgroundElevated)
+                                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: AppTheme.radiusSM)
+                                            .stroke(AppTheme.border, lineWidth: 1)
+                                    )
                                 }
-                                .pickerStyle(MenuPickerStyle())
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                                .background(Color(UIColor.secondarySystemBackground))
-                                .cornerRadius(8)
                             }
                         }
 
                         // Description field
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: AppTheme.spacingSM) {
                             Text("Description (Optional)")
-                                .font(.headline)
-                                .foregroundColor(.primary)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(AppTheme.primary)
 
                             TextField("What are you working on?", text: $description)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(AppTheme.primary)
+                                .padding(AppTheme.spacingMD)
+                                .background(AppTheme.backgroundElevated)
+                                .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusSM))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: AppTheme.radiusSM)
+                                        .stroke(AppTheme.border, lineWidth: 1)
+                                )
                         }
 
                         // Error message
                         if let errorMessage = timerViewModel.errorMessage {
                             Text(errorMessage)
-                                .foregroundColor(.red)
-                                .font(.caption)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(AppTheme.error)
                         }
 
                         // Start button
                         Button(action: {
                             startTimer()
                         }) {
-                            HStack {
+                            HStack(spacing: AppTheme.spacingSM) {
                                 if timerViewModel.isLoading {
                                     ProgressView()
                                         .scaleEffect(0.8)
                                         .progressViewStyle(CircularProgressViewStyle(tint: .white))
                                 }
                                 Image(systemName: "play.fill")
+                                    .font(.system(size: 14, weight: .semibold))
                                 Text(timerViewModel.isLoading ? "Starting..." : "Start Timer")
-                                    .fontWeight(.semibold)
+                                    .font(.system(size: 15, weight: .semibold))
                             }
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(canStartTimer ? Color.green : Color.gray)
                             .foregroundColor(.white)
-                            .cornerRadius(12)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, AppTheme.spacingMD)
+                            .background(canStartTimer ? AppTheme.successGradient : LinearGradient(colors: [AppTheme.tertiary], startPoint: .leading, endPoint: .trailing))
+                            .clipShape(RoundedRectangle(cornerRadius: AppTheme.radiusMD))
                         }
                         .disabled(!canStartTimer || timerViewModel.isLoading)
                     }
                 }
-                .padding()
             }
         }
-        .background(Color(UIColor.tertiarySystemBackground))
         .onAppear {
             // Initialize selected project if there's only one
             if timerViewModel.projects.count == 1 {
@@ -277,4 +272,6 @@ struct TimerView: View {
 #Preview {
     TimerView()
         .environmentObject(TimerViewModel())
+        .padding()
+        .background(AppTheme.background)
 }


### PR DESCRIPTION
## Summary

Apply the same premium dark theme from the macOS app (e0e2f2d) to iOS, ensuring visual consistency across platforms.

## Key Changes

- Extended `AppTheme` with full color palette, gradients, spacing system, and border radius
- Updated all views with premium dark styling (Login, Register, ForgotPassword, Dashboard, Timer, Settings, Legal)
- Redesigned active timer view to match macOS layout (timer + circular stop button on same row)
- Redesigned recent entries to match macOS (inline play button with outline style)
- Added reusable components: `PremiumInputField`, `PremiumPrimaryButtonStyle`, `PremiumSecondaryButtonStyle`
- Moved refresh/settings buttons from timer card to dashboard header
- Removed excessive green styling (earnings now white, green border only on running entry)
- Added pulsating border animation for currently running time entry
- Added form submission on enter for auth forms

## Test Plan

- [x] Verify login/register/forgot password screens match dark theme
- [x] Verify dashboard displays correctly with timer running and stopped
- [x] Verify recent entries show correctly with play button
- [x] Verify settings screen styling
- [x] Verify pulsating border on running entry
- [x] Test form submission on enter key

🤖 Generated with [Claude Code](https://claude.com/claude-code)