### PR TITLE
Add real-time Socket.IO sync to macOS app

### DIFF
--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		38119BE92E06006100F46039 /* IdleAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38119BE82E06006100F46039 /* IdleAlertView.swift */; };
 		38C566342DFD0D910013F6DF /* IdleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C566332DFD0D910013F6DF /* IdleMonitor.swift */; };
+		38A1B5032FFFFFF000000003 /* SocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A1B5042FFFFFF000000004 /* SocketService.swift */; };
+		38A1B5052FFFFFF000000005 /* PollingFallbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A1B5062FFFFFF000000006 /* PollingFallbackService.swift */; };
+		38A1B5072FFFFFF000000007 /* SocketIO in Frameworks */ = {isa = PBXBuildFile; productRef = 38A1B5012FFFFFF000000002 /* SocketIO */; };
 		D0000001000000000 /* TimeTrackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000002000000000 /* TimeTrackApp.swift */; };
 		D0000003000000000 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000004000000000 /* ContentView.swift */; };
 		D0000005000000000 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000006000000000 /* LoginView.swift */; };
@@ -32,6 +35,8 @@
 /* Begin PBXFileReference section */
 		38119BE82E06006100F46039 /* IdleAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleAlertView.swift; sourceTree = "<group>"; };
 		38C566332DFD0D910013F6DF /* IdleMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleMonitor.swift; sourceTree = "<group>"; };
+		38A1B5042FFFFFF000000004 /* SocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketService.swift; sourceTree = "<group>"; };
+		38A1B5062FFFFFF000000006 /* PollingFallbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingFallbackService.swift; sourceTree = "<group>"; };
 		D0000001000000001 /* TimeTrack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TimeTrack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0000002000000000 /* TimeTrackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTrackApp.swift; sourceTree = "<group>"; };
 		D0000004000000000 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -59,6 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				38A1B5072FFFFFF000000007 /* SocketIO in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -129,6 +135,8 @@
 				D0000016000000000 /* AuthService.swift */,
 				D0000018000000000 /* TimerService.swift */,
 				D0000032000000000 /* MenuBarManager.swift */,
+				38A1B5042FFFFFF000000004 /* SocketService.swift */,
+				38A1B5062FFFFFF000000006 /* PollingFallbackService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -165,6 +173,9 @@
 			dependencies = (
 			);
 			name = TimeTrack;
+			packageProductDependencies = (
+				38A1B5012FFFFFF000000002 /* SocketIO */,
+			);
 			productName = TimeTrack;
 			productReference = D0000001000000001 /* TimeTrack.app */;
 			productType = "com.apple.product-type.application";
@@ -193,6 +204,9 @@
 				Base,
 			);
 			mainGroup = D0000001000000003;
+			packageReferences = (
+				38A1B5002FFFFFF000000001 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */,
+			);
 			productRefGroup = D0000001000000005 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -237,6 +251,8 @@
 				D0000033000000000 /* MenuBarView.swift in Sources */,
 				D0000035000000000 /* SharedComponents.swift in Sources */,
 				D0000001000000000 /* TimeTrackApp.swift in Sources */,
+				38A1B5032FFFFFF000000003 /* SocketService.swift in Sources */,
+				38A1B5052FFFFFF000000005 /* PollingFallbackService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -433,6 +449,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		38A1B5002FFFFFF000000001 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/socketio/socket.io-client-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 16.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		38A1B5012FFFFFF000000002 /* SocketIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 38A1B5002FFFFFF000000001 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */;
+			productName = SocketIO;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D0000001000000015 /* Project object */;
 }

--- a/packages/mac-app/TimeTrack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "c9fb241c5f575df8f20b39649006995779013948e60c51c3f85b729f83b054e7",
+  "pins" : [
+    {
+      "identity" : "socket.io-client-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/socketio/socket.io-client-swift",
+      "state" : {
+        "revision" : "42da871d9369f290d6ec4930636c40672143905b",
+        "version" : "16.1.1"
+      }
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream",
+      "state" : {
+        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+        "version" : "4.0.8"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/packages/mac-app/TimeTrack/Models/Models.swift
+++ b/packages/mac-app/TimeTrack/Models/Models.swift
@@ -9,6 +9,7 @@ extension Notification.Name {
     static let idleTimeoutUpdated = Notification.Name("IdleTimeoutUpdated")
     static let userDidLogout = Notification.Name("UserDidLogout")
     static let userDidLogin = Notification.Name("UserDidLogin")
+    static let timerStatePollReceived = Notification.Name("timerStatePollReceived")
 }
 
 // MARK: - User Models

--- a/packages/mac-app/TimeTrack/Services/PollingFallbackService.swift
+++ b/packages/mac-app/TimeTrack/Services/PollingFallbackService.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Combine
+
+@MainActor
+class PollingFallbackService: ObservableObject {
+    static let shared = PollingFallbackService()
+
+    @Published private(set) var isPolling = false
+
+    private var pollingTask: Task<Void, Never>?
+    private var currentInterval: TimeInterval = 5.0
+    private let minInterval: TimeInterval = 5.0
+    private let maxInterval: TimeInterval = 60.0
+
+    private var cancellables = Set<AnyCancellable>()
+    private let apiClient = APIClient.shared
+
+    private init() {
+        // Monitor socket connection state
+        SocketService.shared.$connectionState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                Task { @MainActor in
+                    self?.handleConnectionStateChange(state)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleConnectionStateChange(_ state: SocketService.ConnectionState) {
+        switch state {
+        case .connected:
+            // Socket working, stop polling
+            stopPolling()
+            currentInterval = minInterval // Reset backoff
+
+        case .failed:
+            // Socket failed completely, start polling
+            print("📡 Polling: Socket failed, starting fallback polling")
+            startPolling()
+
+        case .reconnecting:
+            // Start polling during reconnection attempts
+            if !isPolling {
+                print("📡 Polling: Socket reconnecting, starting interim polling")
+                startPolling()
+            }
+
+        default:
+            break
+        }
+    }
+
+    private func startPolling() {
+        guard !isPolling else { return }
+        isPolling = true
+
+        pollingTask = Task {
+            while !Task.isCancelled && isPolling {
+                await performPoll()
+
+                // Increase interval with backoff (slower growth than socket reconnect)
+                currentInterval = min(currentInterval * 1.3, maxInterval)
+
+                try? await Task.sleep(nanoseconds: UInt64(currentInterval * 1_000_000_000))
+            }
+        }
+    }
+
+    private func stopPolling() {
+        guard isPolling else { return }
+        print("📡 Polling: Stopping fallback polling")
+        isPolling = false
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    private func performPoll() async {
+        do {
+            let currentEntry = try await apiClient.getCurrentEntry()
+
+            // Post notification for TimerViewModel to handle
+            NotificationCenter.default.post(
+                name: .timerStatePollReceived,
+                object: nil,
+                userInfo: ["currentEntry": currentEntry as Any]
+            )
+
+            print("📡 Polling: Successfully fetched current entry state")
+
+        } catch {
+            print("📡 Polling: Error fetching state: \(error.localizedDescription)")
+            // Increase backoff on error
+            currentInterval = min(currentInterval * 2, maxInterval)
+        }
+    }
+}

--- a/packages/mac-app/TimeTrack/Services/SocketService.swift
+++ b/packages/mac-app/TimeTrack/Services/SocketService.swift
@@ -1,0 +1,329 @@
+import Foundation
+import Combine
+import SocketIO
+
+@MainActor
+class SocketService: ObservableObject {
+    static let shared = SocketService()
+
+    // MARK: - Published State
+    @Published private(set) var connectionState: ConnectionState = .disconnected
+    @Published private(set) var lastError: String?
+
+    // MARK: - Event Publishers (Timer)
+    let timerStartedSubject = PassthroughSubject<TimeEntry, Never>()
+    let timerStoppedSubject = PassthroughSubject<TimeEntry, Never>()
+    let entryCreatedSubject = PassthroughSubject<TimeEntry, Never>()
+    let entryUpdatedSubject = PassthroughSubject<TimeEntry, Never>()
+    let entryDeletedSubject = PassthroughSubject<String, Never>()
+
+    // MARK: - Event Publishers (Projects)
+    let projectCreatedSubject = PassthroughSubject<Project, Never>()
+    let projectUpdatedSubject = PassthroughSubject<Project, Never>()
+    let projectDeletedSubject = PassthroughSubject<String, Never>()
+
+    // MARK: - Event Publishers (Tasks)
+    let taskCreatedSubject = PassthroughSubject<TimeTrackTask, Never>()
+    let taskUpdatedSubject = PassthroughSubject<TimeTrackTask, Never>()
+    let taskDeletedSubject = PassthroughSubject<String, Never>()
+
+    // MARK: - Private Properties
+    private var manager: SocketManager?
+    private var socket: SocketIOClient?
+    private var currentToken: String?
+    private var reconnectAttempt = 0
+    private var reconnectTask: Task<Void, Never>?
+
+    // MARK: - Configuration
+    private let baseURL: String
+    private let maxReconnectAttempts = 10
+    private let baseReconnectDelay: TimeInterval = 1.0
+    private let maxReconnectDelay: TimeInterval = 30.0
+
+    enum ConnectionState: Equatable {
+        case disconnected
+        case connecting
+        case connected
+        case reconnecting
+        case failed
+    }
+
+    private init() {
+        // Match APIClient's URL resolution
+        if let apiURL = ProcessInfo.processInfo.environment["TIMETRACK_API_URL"] {
+            self.baseURL = apiURL
+        } else {
+            self.baseURL = "https://api.track.alfredo.re"
+        }
+    }
+
+    // MARK: - Public Methods
+
+    func connect(token: String) {
+        guard connectionState != .connected && connectionState != .connecting else {
+            print("🔌 Socket: Already connected or connecting")
+            return
+        }
+
+        self.currentToken = token
+        self.reconnectAttempt = 0
+        connectionState = .connecting
+        print("🔌 Socket: Connecting to \(baseURL)")
+        setupSocket(token: token)
+    }
+
+    func disconnect() {
+        print("🔌 Socket: Disconnecting")
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        socket?.disconnect()
+        manager = nil
+        socket = nil
+        currentToken = nil
+        connectionState = .disconnected
+        lastError = nil
+    }
+
+    // MARK: - Private Setup
+
+    private func setupSocket(token: String) {
+        guard let url = URL(string: baseURL) else {
+            print("❌ Socket: Invalid URL \(baseURL)")
+            lastError = "Invalid server URL"
+            return
+        }
+
+        // Socket.IO Swift client passes auth via extraHeaders for the handshake
+        // The server middleware reads socket.handshake.auth.token
+        let config: SocketIOClientConfiguration = [
+            .log(false),
+            .compress,
+            .forceWebsockets(true),
+            .reconnects(false), // We handle reconnection manually for backoff
+            .extraHeaders(["Authorization": "Bearer \(token)"]),
+            .version(.three) // Ensure we use Socket.IO v3 protocol
+        ]
+
+        manager = SocketManager(socketURL: url, config: config)
+        socket = manager?.defaultSocket
+
+        // Set up event handlers BEFORE connecting
+        setupEventHandlers(token: token)
+
+        // Now connect with auth payload
+        print("🔌 Socket: Initiating connection...")
+        socket?.connect(withPayload: ["token": token])
+    }
+
+    private func setupEventHandlers(token: String) {
+        // Connection lifecycle
+        socket?.on(clientEvent: .connect) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.handleConnect()
+            }
+        }
+
+        socket?.on(clientEvent: .disconnect) { [weak self] data, _ in
+            Task { @MainActor in
+                self?.handleDisconnect(reason: data.first as? String)
+            }
+        }
+
+        socket?.on(clientEvent: .error) { [weak self] data, _ in
+            Task { @MainActor in
+                self?.handleError(data)
+            }
+        }
+
+        // Timer events
+        socket?.on("time-entry-started") { [weak self] data, _ in
+            self?.handleTimeEntryEvent(data, subject: self?.timerStartedSubject, eventName: "started")
+        }
+
+        socket?.on("time-entry-stopped") { [weak self] data, _ in
+            self?.handleTimeEntryEvent(data, subject: self?.timerStoppedSubject, eventName: "stopped")
+        }
+
+        socket?.on("time-entry-created") { [weak self] data, _ in
+            self?.handleTimeEntryEvent(data, subject: self?.entryCreatedSubject, eventName: "created")
+        }
+
+        socket?.on("time-entry-updated") { [weak self] data, _ in
+            self?.handleTimeEntryEvent(data, subject: self?.entryUpdatedSubject, eventName: "updated")
+        }
+
+        socket?.on("time-entry-deleted") { [weak self] data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let id = dict["id"] as? String else { return }
+            Task { @MainActor in
+                print("📥 Socket: time-entry-deleted \(id)")
+                self?.entryDeletedSubject.send(id)
+            }
+        }
+
+        // Project events
+        socket?.on("project-created") { [weak self] data, _ in
+            self?.handleProjectEvent(data, subject: self?.projectCreatedSubject, eventName: "created")
+        }
+
+        socket?.on("project-updated") { [weak self] data, _ in
+            self?.handleProjectEvent(data, subject: self?.projectUpdatedSubject, eventName: "updated")
+        }
+
+        socket?.on("project-deleted") { [weak self] data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let id = dict["id"] as? String else { return }
+            Task { @MainActor in
+                print("📥 Socket: project-deleted \(id)")
+                self?.projectDeletedSubject.send(id)
+            }
+        }
+
+        // Task events
+        socket?.on("task-created") { [weak self] data, _ in
+            self?.handleTaskEvent(data, subject: self?.taskCreatedSubject, eventName: "created")
+        }
+
+        socket?.on("task-updated") { [weak self] data, _ in
+            self?.handleTaskEvent(data, subject: self?.taskUpdatedSubject, eventName: "updated")
+        }
+
+        socket?.on("task-deleted") { [weak self] data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let id = dict["id"] as? String else { return }
+            Task { @MainActor in
+                print("📥 Socket: task-deleted \(id)")
+                self?.taskDeletedSubject.send(id)
+            }
+        }
+    }
+
+    private func handleConnect() {
+        connectionState = .connected
+        reconnectAttempt = 0
+        lastError = nil
+        print("✅ Socket: Connected")
+
+        // Note: With JWT auth middleware, user auto-joins their room on server side
+    }
+
+    private func handleDisconnect(reason: String?) {
+        print("⚠️ Socket: Disconnected (reason: \(reason ?? "unknown"))")
+        guard connectionState != .disconnected else { return }
+
+        // Don't reconnect if we explicitly disconnected
+        if reason == "io client disconnect" {
+            connectionState = .disconnected
+            return
+        }
+
+        scheduleReconnect()
+    }
+
+    private func handleError(_ data: [Any]) {
+        let errorMessage = (data.first as? String) ?? "Unknown error"
+        print("❌ Socket error: \(errorMessage)")
+        lastError = errorMessage
+
+        // Check for auth errors
+        if errorMessage.contains("token") || errorMessage.contains("Authentication") {
+            // Auth failed, don't retry
+            connectionState = .failed
+            print("❌ Socket: Authentication failed, not retrying")
+        }
+    }
+
+    private func handleTimeEntryEvent(_ data: [Any], subject: PassthroughSubject<TimeEntry, Never>?, eventName: String) {
+        guard let dict = data.first as? [String: Any] else {
+            print("❌ Socket: Failed to parse \(eventName) event data")
+            return
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: dict)
+            let decoder = JSONDecoder()
+            let entry = try decoder.decode(TimeEntry.self, from: jsonData)
+            Task { @MainActor in
+                print("📥 Socket: time-entry-\(eventName) for entry \(entry.id)")
+                subject?.send(entry)
+            }
+        } catch {
+            print("❌ Socket: Failed to decode TimeEntry: \(error)")
+        }
+    }
+
+    private func handleProjectEvent(_ data: [Any], subject: PassthroughSubject<Project, Never>?, eventName: String) {
+        guard let dict = data.first as? [String: Any] else {
+            print("❌ Socket: Failed to parse project-\(eventName) event data")
+            return
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: dict)
+            let decoder = JSONDecoder()
+            let project = try decoder.decode(Project.self, from: jsonData)
+            Task { @MainActor in
+                print("📥 Socket: project-\(eventName) for project \(project.id)")
+                subject?.send(project)
+            }
+        } catch {
+            print("❌ Socket: Failed to decode Project: \(error)")
+        }
+    }
+
+    private func handleTaskEvent(_ data: [Any], subject: PassthroughSubject<TimeTrackTask, Never>?, eventName: String) {
+        guard let dict = data.first as? [String: Any] else {
+            print("❌ Socket: Failed to parse task-\(eventName) event data")
+            return
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: dict)
+            let decoder = JSONDecoder()
+            let task = try decoder.decode(TimeTrackTask.self, from: jsonData)
+            Task { @MainActor in
+                print("📥 Socket: task-\(eventName) for task \(task.id)")
+                subject?.send(task)
+            }
+        } catch {
+            print("❌ Socket: Failed to decode Task: \(error)")
+        }
+    }
+
+    // MARK: - Reconnection with Exponential Backoff
+
+    private func scheduleReconnect() {
+        guard let token = currentToken else {
+            print("❌ Socket: No token for reconnection")
+            connectionState = .failed
+            return
+        }
+
+        guard reconnectAttempt < maxReconnectAttempts else {
+            print("❌ Socket: Max reconnection attempts reached, switching to polling fallback")
+            connectionState = .failed
+            return
+        }
+
+        connectionState = .reconnecting
+        reconnectAttempt += 1
+
+        // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (capped)
+        let delay = min(
+            baseReconnectDelay * pow(2.0, Double(reconnectAttempt - 1)),
+            maxReconnectDelay
+        )
+
+        print("🔄 Socket: Reconnection attempt \(reconnectAttempt)/\(maxReconnectAttempts) in \(delay)s")
+
+        reconnectTask = Task {
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                // Recreate socket with fresh connection
+                self.setupSocket(token: token)
+            }
+        }
+    }
+}

--- a/packages/mac-app/TimeTrack/ViewModels/AuthViewModel.swift
+++ b/packages/mac-app/TimeTrack/ViewModels/AuthViewModel.swift
@@ -70,6 +70,9 @@ class AuthViewModel: ObservableObject {
     }
 
     func logout() {
+        // Disconnect Socket.IO
+        SocketService.shared.disconnect()
+
         apiClient.clearToken()
         currentUser = nil
         isAuthenticated = false
@@ -126,6 +129,14 @@ class AuthViewModel: ObservableObject {
         currentUser = user
         isAuthenticated = true
         persistIdleTimeout(seconds: user.idleTimeoutSeconds)
+
+        // Connect to Socket.IO with JWT token
+        if let token = apiClient.authToken {
+            SocketService.shared.connect(token: token)
+
+            // Initialize polling fallback (auto-monitors socket state)
+            _ = PollingFallbackService.shared
+        }
 
         // Notify other components to reload their data
         NotificationCenter.default.post(name: .userDidLogin, object: nil)

--- a/packages/mac-app/TimeTrack/ViewModels/TimerViewModel.swift
+++ b/packages/mac-app/TimeTrack/ViewModels/TimerViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import AppKit
+import Combine
 
 @MainActor
 class TimerViewModel: ObservableObject {
@@ -25,6 +26,7 @@ class TimerViewModel: ObservableObject {
     private var idleMonitor: IdleMonitor?
     private var idleTimeoutSeconds: Int
     private var idleTimeoutObserver: NSObjectProtocol?
+    private var socketCancellables = Set<AnyCancellable>()
 
     var isRunning: Bool {
         currentEntry?.isRunning ?? false
@@ -67,6 +69,10 @@ class TimerViewModel: ObservableObject {
         configureIdleMonitor()
         observeIdleTimeoutChanges()
         observeLogout()
+
+        // Set up Socket.IO subscriptions for real-time updates
+        setupSocketSubscriptions()
+        observePollFallback()
     }
 
     private func observeLogout() {
@@ -371,6 +377,310 @@ class TimerViewModel: ObservableObject {
         selectedTaskId = nil
         errorMessage = nil
         stopElapsedTimer()
+    }
+
+    // MARK: - Socket.IO Subscriptions
+
+    private func setupSocketSubscriptions() {
+        let socketService = SocketService.shared
+
+        // Timer started remotely
+        socketService.timerStartedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] entry in
+                Task { @MainActor in
+                    self?.handleRemoteTimerStarted(entry)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Timer stopped remotely
+        socketService.timerStoppedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] entry in
+                Task { @MainActor in
+                    self?.handleRemoteTimerStopped(entry)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Entry created remotely
+        socketService.entryCreatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] entry in
+                Task { @MainActor in
+                    self?.handleRemoteEntryCreated(entry)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Entry updated remotely
+        socketService.entryUpdatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] entry in
+                Task { @MainActor in
+                    self?.handleRemoteEntryUpdated(entry)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Entry deleted remotely
+        socketService.entryDeletedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] entryId in
+                Task { @MainActor in
+                    self?.handleRemoteEntryDeleted(entryId)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Project events
+        socketService.projectCreatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] project in
+                Task { @MainActor in
+                    self?.handleRemoteProjectCreated(project)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        socketService.projectUpdatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] project in
+                Task { @MainActor in
+                    self?.handleRemoteProjectUpdated(project)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        socketService.projectDeletedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] projectId in
+                Task { @MainActor in
+                    self?.handleRemoteProjectDeleted(projectId)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        // Task events
+        socketService.taskCreatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] task in
+                Task { @MainActor in
+                    self?.handleRemoteTaskCreated(task)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        socketService.taskUpdatedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] task in
+                Task { @MainActor in
+                    self?.handleRemoteTaskUpdated(task)
+                }
+            }
+            .store(in: &socketCancellables)
+
+        socketService.taskDeletedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] taskId in
+                Task { @MainActor in
+                    self?.handleRemoteTaskDeleted(taskId)
+                }
+            }
+            .store(in: &socketCancellables)
+    }
+
+    // MARK: - Remote Timer Event Handlers
+
+    private func handleRemoteTimerStarted(_ entry: TimeEntry) {
+        print("⏱️ Remote timer started: \(entry.id)")
+
+        // Update current entry if we don't already have it running
+        guard currentEntry?.id != entry.id else { return }
+
+        currentEntry = entry
+        if entry.isRunning {
+            calculateElapsedTime(from: entry.startTime)
+            startElapsedTimer()
+        }
+    }
+
+    private func handleRemoteTimerStopped(_ entry: TimeEntry) {
+        print("⏹️ Remote timer stopped: \(entry.id)")
+
+        // If the stopped entry is our current running entry
+        if currentEntry?.id == entry.id {
+            currentEntry = entry
+            stopElapsedTimer()
+            elapsedTime = 0
+        }
+
+        // Refresh recent entries list
+        Task {
+            await loadRecentEntries()
+        }
+    }
+
+    private func handleRemoteEntryCreated(_ entry: TimeEntry) {
+        print("📝 Remote entry created: \(entry.id)")
+
+        // Add to recent entries if not already present
+        if !recentEntries.contains(where: { $0.id == entry.id }) {
+            recentEntries.insert(entry, at: 0)
+            // Keep only recent 10
+            if recentEntries.count > 10 {
+                recentEntries.removeLast()
+            }
+        }
+    }
+
+    private func handleRemoteEntryUpdated(_ entry: TimeEntry) {
+        print("📝 Remote entry updated: \(entry.id)")
+
+        // Update in recent entries list
+        if let index = recentEntries.firstIndex(where: { $0.id == entry.id }) {
+            recentEntries[index] = entry
+        }
+
+        // Update current entry if it matches
+        if currentEntry?.id == entry.id {
+            let wasRunning = currentEntry?.isRunning ?? false
+            currentEntry = entry
+
+            // Handle running state changes
+            if entry.isRunning && !wasRunning {
+                calculateElapsedTime(from: entry.startTime)
+                startElapsedTimer()
+            } else if !entry.isRunning && wasRunning {
+                stopElapsedTimer()
+                elapsedTime = 0
+            }
+        }
+    }
+
+    private func handleRemoteEntryDeleted(_ entryId: String) {
+        print("🗑️ Remote entry deleted: \(entryId)")
+
+        // Remove from recent entries
+        recentEntries.removeAll { $0.id == entryId }
+
+        // Clear current entry if it was deleted
+        if currentEntry?.id == entryId {
+            currentEntry = nil
+            stopElapsedTimer()
+            elapsedTime = 0
+        }
+    }
+
+    // MARK: - Remote Project Event Handlers
+
+    private func handleRemoteProjectCreated(_ project: Project) {
+        print("📁 Remote project created: \(project.id)")
+
+        // Add to projects list if not already present
+        if !projects.contains(where: { $0.id == project.id }) {
+            projects.append(project)
+        }
+    }
+
+    private func handleRemoteProjectUpdated(_ project: Project) {
+        print("📁 Remote project updated: \(project.id)")
+
+        // Update in projects list
+        if let index = projects.firstIndex(where: { $0.id == project.id }) {
+            projects[index] = project
+        }
+    }
+
+    private func handleRemoteProjectDeleted(_ projectId: String) {
+        print("🗑️ Remote project deleted: \(projectId)")
+
+        // Remove from projects list
+        projects.removeAll { $0.id == projectId }
+
+        // Clear selected project if it was deleted
+        if selectedProjectId == projectId {
+            selectedProjectId = nil
+            selectedTaskId = nil
+            tasks = []
+        }
+    }
+
+    // MARK: - Remote Task Event Handlers
+
+    private func handleRemoteTaskCreated(_ task: TimeTrackTask) {
+        print("📋 Remote task created: \(task.id)")
+
+        // Add to tasks list if it belongs to the currently selected project
+        if let project = task.project, project.id == selectedProjectId {
+            if !tasks.contains(where: { $0.id == task.id }) {
+                tasks.append(task)
+            }
+        }
+    }
+
+    private func handleRemoteTaskUpdated(_ task: TimeTrackTask) {
+        print("📋 Remote task updated: \(task.id)")
+
+        // Update in tasks list
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            tasks[index] = task
+        }
+    }
+
+    private func handleRemoteTaskDeleted(_ taskId: String) {
+        print("🗑️ Remote task deleted: \(taskId)")
+
+        // Remove from tasks list
+        tasks.removeAll { $0.id == taskId }
+
+        // Clear selected task if it was deleted
+        if selectedTaskId == taskId {
+            selectedTaskId = nil
+        }
+    }
+
+    // MARK: - Polling Fallback
+
+    private func observePollFallback() {
+        NotificationCenter.default.addObserver(
+            forName: .timerStatePollReceived,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in
+                if let entry = notification.userInfo?["currentEntry"] as? TimeEntry? {
+                    self?.handlePolledTimerState(entry)
+                }
+            }
+        }
+    }
+
+    private func handlePolledTimerState(_ entry: TimeEntry?) {
+        // Only update if state differs from current
+        let currentId = currentEntry?.id
+        let currentRunning = currentEntry?.isRunning ?? false
+        let newId = entry?.id
+        let newRunning = entry?.isRunning ?? false
+
+        // State changed
+        if currentId != newId || currentRunning != newRunning {
+            currentEntry = entry
+
+            if let entry = entry, entry.isRunning {
+                calculateElapsedTime(from: entry.startTime)
+                startElapsedTimer()
+            } else {
+                stopElapsedTimer()
+                elapsedTime = 0
+            }
+
+            // Also refresh recent entries
+            Task {
+                await loadRecentEntries()
+            }
+        }
     }
 
     // MARK: - Auto Refresh Setup


### PR DESCRIPTION
## Summary

- Adds Socket.IO real-time synchronization to the macOS app, mirroring the iOS implementation from PR #65
- Enables instant UI updates when timers are started/stopped from other clients (web, iOS, Electron)
- Includes automatic fallback polling when WebSocket connection fails

## Key Changes

- **SocketService.swift**: Core Socket.IO client with JWT authentication, event handling, and exponential backoff reconnection
- **PollingFallbackService.swift**: Fallback polling service that activates when Socket.IO fails
- **TimerViewModel.swift**: Added subscriptions for all socket events and remote event handlers
- **AuthViewModel.swift**: Socket connect on login, disconnect on logout

## Events Handled

| Event | Action |
|-------|--------|
| `time-entry-started` | Update currentEntry, start elapsed timer |
| `time-entry-stopped` | Update currentEntry, stop elapsed timer |
| `time-entry-created/updated/deleted` | Update recent entries list |
| `project-created/updated/deleted` | Update projects list |
| `task-created/updated/deleted` | Update tasks list |

## Test plan

- [ ] Start timer on web → macOS app updates instantly
- [ ] Stop timer on iOS → macOS app updates instantly
- [ ] Create project on Electron → macOS app list updates
- [ ] Disconnect network → Polling fallback activates
- [ ] Reconnect network → Socket.IO reconnects, polling stops
- [ ] Logout → Socket disconnects cleanly
- [ ] Login → Socket connects with new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)