### PR TITLE
Fix deploy health check with retry loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,20 @@ jobs:
             ./deploy.sh prod
 
             echo "=== Verifying health ==="
-            sleep 10
             for service in "3011/health" "3010/health"; do
-              if curl -sf "http://localhost:${service}" > /dev/null; then
-                echo "✓ localhost:${service} is healthy"
-              else
-                echo "✗ localhost:${service} failed health check"
-                exit 1
-              fi
+              echo "Waiting for localhost:${service}..."
+              for i in $(seq 1 30); do
+                if curl -sf "http://localhost:${service}" > /dev/null 2>&1; then
+                  echo "✓ localhost:${service} is healthy"
+                  break
+                fi
+                if [ "$i" -eq 30 ]; then
+                  echo "✗ localhost:${service} failed health check after 30 attempts"
+                  docker logs timetrack-api-prod --tail 50 2>&1 || true
+                  exit 1
+                fi
+                sleep 2
+              done
             done
 
             echo "=== Deploy complete ==="


### PR DESCRIPTION
## Summary
- Replace single-shot health check (10s sleep + one curl) with a retry loop
- Fixes the failed deploy action from #71 where the API wasn't ready in time

## What changed
The health check now retries up to 30 times with 2-second intervals (up to 60s per service) instead of a single attempt after a fixed 10-second sleep. It exits as soon as the service responds, so deploys aren't slowed down when startup is fast. On failure, it dumps the last 50 lines of API container logs for debugging.

## Test plan
- [ ] Merge and verify the deploy action passes health checks