### PR TITLE
Store auth tokens in Keychain instead of UserDefaults

### DIFF
--- a/packages/ios-app/Timetrack/Timetrack/Services/KeychainHelper.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Services/KeychainHelper.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let service = "com.timetrack.ios"
+    private static let accessGroup = "group.com.timetrack.shared"
+
+    @discardableResult
+    static func save(token: String, forKey key: String) -> Bool {
+        guard let data = token.data(using: .utf8) else { return false }
+
+        // Delete existing item first
+        delete(forKey: key)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        #if DEBUG
+        if status != errSecSuccess {
+            print("KeychainHelper: SecItemAdd failed with status \(status)")
+        }
+        #endif
+        return status == errSecSuccess
+    }
+
+    static func get(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(forKey key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/packages/mac-app/TimeTrack/Services/KeychainHelper.swift
+++ b/packages/mac-app/TimeTrack/Services/KeychainHelper.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let service = "com.timetrack.macos"
+
+    @discardableResult
+    static func save(token: String, forKey key: String) -> Bool {
+        guard let data = token.data(using: .utf8) else { return false }
+
+        // Delete existing item first
+        delete(forKey: key)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        #if DEBUG
+        if status != errSecSuccess {
+            print("KeychainHelper: SecItemAdd failed with status \(status)")
+        }
+        #endif
+        return status == errSecSuccess
+    }
+
+    static func get(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(forKey key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}


### PR DESCRIPTION
## Summary

- **Keychain storage**: Both macOS and iOS apps now store JWT auth tokens in the system Keychain instead of plaintext UserDefaults plist files
- **Automatic migration**: Existing users' tokens are migrated from UserDefaults to Keychain on first launch, then old entries are cleaned up
- **Shared access**: iOS Keychain uses `group.com.timetrack.shared` access group so the Watch app, Live Activity widget, and main app all share the same token
- **Debug logging cleanup**: Removed all `print()` statements that logged token prefixes in production builds; remaining debug prints gated behind `#if DEBUG`
- **Removed test artifacts**: Deleted `ensureTokenInSharedStorage()` which wrote `test-key`/`test-value` to shared storage on every launch
- **Watch connectivity hardened**: WatchConnectivityManager now stores received auth tokens in Keychain instead of UserDefaults; WatchConnectivityService debug prints gated behind `#if DEBUG`
- **Safe migration**: Keychain write success is verified before deleting old UserDefaults entries, preventing token loss on write failure

## Files

| File | Action |
|------|--------|
| `packages/mac-app/TimeTrack/Services/KeychainHelper.swift` | **NEW** — Keychain helper for macOS |
| `packages/ios-app/Timetrack/Timetrack/Services/KeychainHelper.swift` | **NEW** — Keychain helper for iOS with shared access group |
| `packages/mac-app/TimeTrack/Services/APIClient.swift` | Modified — Use Keychain, migrate from UserDefaults |
| `packages/ios-app/Timetrack/Timetrack/Services/APIClient.swift` | Modified — Use Keychain, remove debug logging, remove test writes |
| `packages/ios-app/Timetrack/TimetrackLiveActivity/StopTimerIntent.swift` | Modified — Inline Keychain read instead of shared UserDefaults |
| `packages/ios-app/Timetrack/Timetrack Watch Watch App/APIClient.swift` | Modified — Inline Keychain read, remove all debug prints |
| `packages/ios-app/Timetrack/Timetrack Watch Watch App/Timetrack_WatchApp.swift` | Modified — WatchConnectivityManager uses Keychain for token cache |
| `packages/ios-app/Timetrack/Timetrack/Services/WatchConnectivityService.swift` | Modified — Gate debug prints behind `#if DEBUG` |

## Post-merge: Xcode target membership

The new `KeychainHelper.swift` files need to be added to their respective Xcode targets:
- macOS `KeychainHelper.swift` → add to `TimeTrack` target
- iOS `KeychainHelper.swift` → add to `Timetrack` target

The Watch app and Live Activity widget use inline Keychain helpers to avoid target membership complexity.

## Test plan

- [ ] Build macOS app — verify it compiles without errors
- [ ] Build iOS app — verify all targets compile (main app, Watch, Live Activity)
- [ ] Test login flow — token should be saved to Keychain, NOT UserDefaults
- [ ] Test app restart — token should persist from Keychain
- [ ] Verify no token-related `print()` output in release builds
- [ ] Check that existing users' tokens migrate from UserDefaults to Keychain on first launch
- [ ] Verify Watch app receives and stores token in Keychain (not UserDefaults) via WatchConnectivity