### PR TITLE
Wire up WatchConnectivity for real-time timer sync

### DIFF
--- a/packages/ios-app/Timetrack/Timetrack Watch Watch App/Timetrack_WatchApp.swift
+++ b/packages/ios-app/Timetrack/Timetrack Watch Watch App/Timetrack_WatchApp.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import WatchKit
 import WatchConnectivity
-import Security
 
 @main
 struct TimeTrackWatchApp: App {
@@ -27,90 +26,57 @@ class WatchConnectivityManager: NSObject, ObservableObject {
     @Published var errorMessage: String?
     
     private var authToken: String?
-
+    
     override init() {
         super.init()
         setupWatchConnectivity()
         loadStoredData()
     }
-
+    
     private func setupWatchConnectivity() {
         if WCSession.isSupported() {
             let session = WCSession.default
             session.delegate = self
             session.activate()
-            #if DEBUG
-            print("Watch: WatchConnectivity activated")
-            #endif
+            print("⌚ Watch: WatchConnectivity activated")
         }
     }
-
-    // NOTE: Service, account, and access group must match KeychainHelper.swift in the main app target.
-    private func getTokenFromKeychain() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "com.timetrack.ios",
-            kSecAttrAccount as String: "timetrack_auth_token",
-            kSecAttrAccessGroup as String: "group.com.timetrack.shared",
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
-    }
-
-    private func saveTokenToKeychain(_ token: String) {
-        guard let data = token.data(using: .utf8) else { return }
-
-        // Delete existing item first
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "com.timetrack.ios",
-            kSecAttrAccount as String: "timetrack_auth_token",
-            kSecAttrAccessGroup as String: "group.com.timetrack.shared"
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "com.timetrack.ios",
-            kSecAttrAccount as String: "timetrack_auth_token",
-            kSecAttrAccessGroup as String: "group.com.timetrack.shared",
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
-        ]
-        SecItemAdd(addQuery as CFDictionary, nil)
-    }
-
+    
     private func loadStoredData() {
-        // Load auth token from Keychain, migrating from UserDefaults if needed
-        if let token = getTokenFromKeychain() {
+        // Load cached data from UserDefaults
+        if let tokenData = UserDefaults.standard.data(forKey: "cached_auth_token"),
+           let token = String(data: tokenData, encoding: .utf8) {
             authToken = token
-        } else if let tokenData = UserDefaults.standard.data(forKey: "cached_auth_token"),
-                  let token = String(data: tokenData, encoding: .utf8) {
-            // One-time migration from UserDefaults to Keychain
-            authToken = token
-            saveTokenToKeychain(token)
-            UserDefaults.standard.removeObject(forKey: "cached_auth_token")
+            print("⌚ Watch: Loaded cached auth token")
         }
-
-        // Load non-sensitive cached data from UserDefaults
+        
         if let projectsData = UserDefaults.standard.data(forKey: "cached_projects"),
            let projectsArray = try? JSONDecoder().decode([WatchProject].self, from: projectsData) {
             projects = projectsArray
+            print("⌚ Watch: Loaded \(projects.count) cached projects")
         }
-
+        
         if let entriesData = UserDefaults.standard.data(forKey: "cached_recent_entries"),
            let entriesArray = try? JSONDecoder().decode([WatchTimeEntry].self, from: entriesData) {
             recentEntries = entriesArray
+            print("⌚ Watch: Loaded \(recentEntries.count) cached entries")
         }
-
+        
         currentEarnings = UserDefaults.standard.double(forKey: "cached_earnings")
         todaysHours = UserDefaults.standard.double(forKey: "cached_todays_hours")
         isTimerRunning = UserDefaults.standard.bool(forKey: "cached_timer_running")
         currentProject = UserDefaults.standard.string(forKey: "cached_current_project") ?? "No Active Project"
+        
+        // Check for any pending application context from iPhone
+        let context = WCSession.default.receivedApplicationContext
+        if !context.isEmpty {
+            if let isRunning = context["is_timer_running"] as? Bool {
+                isTimerRunning = isRunning
+            }
+            if let project = context["current_project"] as? String, !project.isEmpty {
+                currentProject = project
+            }
+        }
 
         // Request fresh data from iPhone
         requestDataFromiPhone()
@@ -123,20 +89,18 @@ class WatchConnectivityManager: NSObject, ObservableObject {
         
         if WCSession.default.isReachable {
             WCSession.default.sendMessage(request, replyHandler: nil) { error in
-                #if DEBUG
-                print("Watch: Failed to request data: \(error)")
-                #endif
+                print("⌚ Watch: Failed to request data: \(error)")
             }
         }
     }
     
     private func saveDataToCache() {
-        // Save auth token to Keychain (not UserDefaults)
+        // Cache auth token
         if let token = authToken {
-            saveTokenToKeychain(token)
+            UserDefaults.standard.set(token.data(using: .utf8), forKey: "cached_auth_token")
         }
-
-        // Cache non-sensitive data in UserDefaults
+        
+        // Cache projects
         if let projectsData = try? JSONEncoder().encode(projects) {
             UserDefaults.standard.set(projectsData, forKey: "cached_projects")
         }
@@ -212,23 +176,42 @@ class WatchConnectivityManager: NSObject, ObservableObject {
 extension WatchConnectivityManager: WCSessionDelegate {
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         if let error = error {
-            #if DEBUG
-            print("Watch: WatchConnectivity activation failed: \(error)")
-            #endif
+            print("⌚ Watch: WatchConnectivity activation failed: \(error)")
         } else {
+            print("⌚ Watch: WatchConnectivity activated successfully")
             DispatchQueue.main.async {
                 self.requestDataFromiPhone()
             }
         }
     }
+    
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        print("⌚ Watch: Received application context: \(applicationContext.keys)")
+
+        DispatchQueue.main.async {
+            if let isRunning = applicationContext["is_timer_running"] as? Bool {
+                self.isTimerRunning = isRunning
+            }
+            if let project = applicationContext["current_project"] as? String, !project.isEmpty {
+                self.currentProject = project
+            } else if applicationContext["is_timer_running"] as? Bool == false {
+                self.currentProject = "No Active Project"
+            }
+
+            self.saveDataToCache()
+        }
+    }
 
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
+        print("⌚ Watch: Received user info: \(userInfo.keys)")
+        
         DispatchQueue.main.async {
             // Handle auth token
             if let token = userInfo["auth_token"] as? String {
                 self.authToken = token
+                print("⌚ Watch: Received auth token from iPhone")
             }
-
+            
             // Handle projects data
             if let projectsData = userInfo["projects"] as? [[String: Any]] {
                 self.projects = projectsData.compactMap { dict in
@@ -237,16 +220,18 @@ extension WatchConnectivityManager: WCSessionDelegate {
                           let color = dict["color"] as? String else { return nil }
                     return WatchProject(id: id, name: name, color: color)
                 }
+                print("⌚ Watch: Received \(self.projects.count) projects from iPhone")
             }
-
+            
             // Handle dashboard data
             if let dashboardData = userInfo["dashboard"] as? [String: Any] {
                 self.currentEarnings = dashboardData["current_earnings"] as? Double ?? 0.0
                 self.isTimerRunning = dashboardData["is_timer_running"] as? Bool ?? false
                 self.todaysHours = dashboardData["todays_hours"] as? Double ?? 0.0
                 self.currentProject = dashboardData["current_project"] as? String ?? "No Active Project"
+                print("⌚ Watch: Received dashboard data from iPhone")
             }
-
+            
             // Handle recent entries
             if let entriesData = userInfo["recent_entries"] as? [[String: Any]] {
                 self.recentEntries = entriesData.compactMap { dict in
@@ -255,10 +240,10 @@ extension WatchConnectivityManager: WCSessionDelegate {
                           let duration = dict["duration"] as? Int,
                           let hourlyRate = dict["hourly_rate"] as? Double,
                           let startTime = dict["start_time"] as? String else { return nil }
-
+                    
                     let taskName = dict["task_name"] as? String
                     let date = self.parseDate(startTime)
-
+                    
                     return WatchTimeEntry(
                         id: id,
                         projectName: projectName,
@@ -268,8 +253,9 @@ extension WatchConnectivityManager: WCSessionDelegate {
                         date: date
                     )
                 }
+                print("⌚ Watch: Received \(self.recentEntries.count) recent entries from iPhone")
             }
-
+            
             self.saveDataToCache()
             self.errorMessage = nil
             self.isLoading = false
@@ -277,7 +263,15 @@ extension WatchConnectivityManager: WCSessionDelegate {
     }
     
     private func parseDate(_ dateString: String) -> Date {
-        WatchDateUtils.parseISO8601(dateString) ?? Date()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+        
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: dateString) ?? Date()
     }
 }
 

--- a/packages/ios-app/Timetrack/Timetrack Watch Watch App/Timetrack_WatchApp.swift
+++ b/packages/ios-app/Timetrack/Timetrack Watch Watch App/Timetrack_WatchApp.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 import WatchKit
 import WatchConnectivity
+import Security
 
 @main
 struct TimeTrackWatchApp: App {
     @StateObject private var watchConnectivity = WatchConnectivityManager()
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -24,49 +25,92 @@ class WatchConnectivityManager: NSObject, ObservableObject {
     @Published var projects: [WatchProject] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
-    
+
     private var authToken: String?
-    
+
     override init() {
         super.init()
         setupWatchConnectivity()
         loadStoredData()
     }
-    
+
+    // NOTE: Service, account, and access group must match KeychainHelper.swift in the main app target.
+    private func getTokenFromKeychain() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.timetrack.ios",
+            kSecAttrAccount as String: "timetrack_auth_token",
+            kSecAttrAccessGroup as String: "group.com.timetrack.shared",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func saveTokenToKeychain(_ token: String) {
+        guard let data = token.data(using: .utf8) else { return }
+
+        // Delete existing item first
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.timetrack.ios",
+            kSecAttrAccount as String: "timetrack_auth_token",
+            kSecAttrAccessGroup as String: "group.com.timetrack.shared"
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.timetrack.ios",
+            kSecAttrAccount as String: "timetrack_auth_token",
+            kSecAttrAccessGroup as String: "group.com.timetrack.shared",
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
     private func setupWatchConnectivity() {
         if WCSession.isSupported() {
             let session = WCSession.default
             session.delegate = self
             session.activate()
-            print("⌚ Watch: WatchConnectivity activated")
+            #if DEBUG
+            print("Watch: WatchConnectivity activated")
+            #endif
         }
     }
-    
+
     private func loadStoredData() {
-        // Load cached data from UserDefaults
-        if let tokenData = UserDefaults.standard.data(forKey: "cached_auth_token"),
-           let token = String(data: tokenData, encoding: .utf8) {
+        // Load auth token from Keychain, migrating from UserDefaults if needed
+        if let token = getTokenFromKeychain() {
             authToken = token
-            print("⌚ Watch: Loaded cached auth token")
+        } else if let tokenData = UserDefaults.standard.data(forKey: "cached_auth_token"),
+                  let token = String(data: tokenData, encoding: .utf8) {
+            // One-time migration from UserDefaults to Keychain
+            authToken = token
+            saveTokenToKeychain(token)
+            UserDefaults.standard.removeObject(forKey: "cached_auth_token")
         }
-        
+
         if let projectsData = UserDefaults.standard.data(forKey: "cached_projects"),
            let projectsArray = try? JSONDecoder().decode([WatchProject].self, from: projectsData) {
             projects = projectsArray
-            print("⌚ Watch: Loaded \(projects.count) cached projects")
         }
-        
+
         if let entriesData = UserDefaults.standard.data(forKey: "cached_recent_entries"),
            let entriesArray = try? JSONDecoder().decode([WatchTimeEntry].self, from: entriesData) {
             recentEntries = entriesArray
-            print("⌚ Watch: Loaded \(recentEntries.count) cached entries")
         }
-        
+
         currentEarnings = UserDefaults.standard.double(forKey: "cached_earnings")
         todaysHours = UserDefaults.standard.double(forKey: "cached_todays_hours")
         isTimerRunning = UserDefaults.standard.bool(forKey: "cached_timer_running")
         currentProject = UserDefaults.standard.string(forKey: "cached_current_project") ?? "No Active Project"
-        
+
         // Check for any pending application context from iPhone
         let context = WCSession.default.receivedApplicationContext
         if !context.isEmpty {
@@ -81,48 +125,50 @@ class WatchConnectivityManager: NSObject, ObservableObject {
         // Request fresh data from iPhone
         requestDataFromiPhone()
     }
-    
+
     private func requestDataFromiPhone() {
         guard WCSession.default.activationState == .activated else { return }
-        
+
         let request = ["request": "sync_all_data"]
-        
+
         if WCSession.default.isReachable {
             WCSession.default.sendMessage(request, replyHandler: nil) { error in
-                print("⌚ Watch: Failed to request data: \(error)")
+                #if DEBUG
+                print("Watch: Failed to request data: \(error)")
+                #endif
             }
         }
     }
-    
+
     private func saveDataToCache() {
-        // Cache auth token
+        // Save auth token to Keychain (not UserDefaults)
         if let token = authToken {
-            UserDefaults.standard.set(token.data(using: .utf8), forKey: "cached_auth_token")
+            saveTokenToKeychain(token)
         }
-        
-        // Cache projects
+
+        // Cache non-sensitive data in UserDefaults
         if let projectsData = try? JSONEncoder().encode(projects) {
             UserDefaults.standard.set(projectsData, forKey: "cached_projects")
         }
-        
+
         // Cache recent entries
         if let entriesData = try? JSONEncoder().encode(recentEntries) {
             UserDefaults.standard.set(entriesData, forKey: "cached_recent_entries")
         }
-        
+
         // Cache dashboard data
         UserDefaults.standard.set(currentEarnings, forKey: "cached_earnings")
         UserDefaults.standard.set(todaysHours, forKey: "cached_todays_hours")
         UserDefaults.standard.set(isTimerRunning, forKey: "cached_timer_running")
         UserDefaults.standard.set(currentProject, forKey: "cached_current_project")
     }
-    
+
     func startTimer(for project: WatchProject) {
         guard WCSession.default.isReachable else {
             errorMessage = "iPhone not reachable. Make sure your iPhone is nearby and the TimeTrack app is open."
             return
         }
-        
+
         let message = ["request": "start_timer", "project_id": project.id]
         WCSession.default.sendMessage(message, replyHandler: { reply in
             DispatchQueue.main.async {
@@ -138,13 +184,13 @@ class WatchConnectivityManager: NSObject, ObservableObject {
             }
         })
     }
-    
+
     func stopTimer() {
         guard WCSession.default.isReachable else {
             errorMessage = "iPhone not reachable. Make sure your iPhone is nearby and the TimeTrack app is open."
             return
         }
-        
+
         let message = ["request": "stop_timer"]
         WCSession.default.sendMessage(message, replyHandler: { reply in
             DispatchQueue.main.async {
@@ -160,13 +206,13 @@ class WatchConnectivityManager: NSObject, ObservableObject {
             }
         })
     }
-    
+
     func restartEntry(_ entry: WatchTimeEntry) {
         if let project = projects.first(where: { $0.name == entry.projectName }) {
             startTimer(for: project)
         }
     }
-    
+
     func refresh() {
         requestDataFromiPhone()
     }
@@ -176,17 +222,20 @@ class WatchConnectivityManager: NSObject, ObservableObject {
 extension WatchConnectivityManager: WCSessionDelegate {
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         if let error = error {
-            print("⌚ Watch: WatchConnectivity activation failed: \(error)")
+            #if DEBUG
+            print("Watch: WatchConnectivity activation failed: \(error)")
+            #endif
         } else {
-            print("⌚ Watch: WatchConnectivity activated successfully")
             DispatchQueue.main.async {
                 self.requestDataFromiPhone()
             }
         }
     }
-    
+
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        print("⌚ Watch: Received application context: \(applicationContext.keys)")
+        #if DEBUG
+        print("Watch: Received application context: \(applicationContext.keys)")
+        #endif
 
         DispatchQueue.main.async {
             if let isRunning = applicationContext["is_timer_running"] as? Bool {
@@ -203,15 +252,16 @@ extension WatchConnectivityManager: WCSessionDelegate {
     }
 
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
-        print("⌚ Watch: Received user info: \(userInfo.keys)")
-        
+        #if DEBUG
+        print("Watch: Received user info: \(userInfo.keys)")
+        #endif
+
         DispatchQueue.main.async {
             // Handle auth token
             if let token = userInfo["auth_token"] as? String {
                 self.authToken = token
-                print("⌚ Watch: Received auth token from iPhone")
             }
-            
+
             // Handle projects data
             if let projectsData = userInfo["projects"] as? [[String: Any]] {
                 self.projects = projectsData.compactMap { dict in
@@ -220,18 +270,16 @@ extension WatchConnectivityManager: WCSessionDelegate {
                           let color = dict["color"] as? String else { return nil }
                     return WatchProject(id: id, name: name, color: color)
                 }
-                print("⌚ Watch: Received \(self.projects.count) projects from iPhone")
             }
-            
+
             // Handle dashboard data
             if let dashboardData = userInfo["dashboard"] as? [String: Any] {
                 self.currentEarnings = dashboardData["current_earnings"] as? Double ?? 0.0
                 self.isTimerRunning = dashboardData["is_timer_running"] as? Bool ?? false
                 self.todaysHours = dashboardData["todays_hours"] as? Double ?? 0.0
                 self.currentProject = dashboardData["current_project"] as? String ?? "No Active Project"
-                print("⌚ Watch: Received dashboard data from iPhone")
             }
-            
+
             // Handle recent entries
             if let entriesData = userInfo["recent_entries"] as? [[String: Any]] {
                 self.recentEntries = entriesData.compactMap { dict in
@@ -240,10 +288,10 @@ extension WatchConnectivityManager: WCSessionDelegate {
                           let duration = dict["duration"] as? Int,
                           let hourlyRate = dict["hourly_rate"] as? Double,
                           let startTime = dict["start_time"] as? String else { return nil }
-                    
+
                     let taskName = dict["task_name"] as? String
                     let date = self.parseDate(startTime)
-                    
+
                     return WatchTimeEntry(
                         id: id,
                         projectName: projectName,
@@ -253,25 +301,23 @@ extension WatchConnectivityManager: WCSessionDelegate {
                         date: date
                     )
                 }
-                print("⌚ Watch: Received \(self.recentEntries.count) recent entries from iPhone")
             }
-            
+
             self.saveDataToCache()
             self.errorMessage = nil
             self.isLoading = false
         }
     }
-    
+
     private func parseDate(_ dateString: String) -> Date {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        
+
         if let date = formatter.date(from: dateString) {
             return date
         }
-        
+
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: dateString) ?? Date()
     }
 }
-

--- a/packages/ios-app/Timetrack/Timetrack/Services/WatchConnectivityService.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Services/WatchConnectivityService.swift
@@ -3,38 +3,40 @@ import WatchConnectivity
 
 class WatchConnectivityService: NSObject, ObservableObject {
     static let shared = WatchConnectivityService()
-    
+
     private override init() {
         super.init()
         setupWatchConnectivity()
     }
-    
+
     private func setupWatchConnectivity() {
         if WCSession.isSupported() {
             let session = WCSession.default
             session.delegate = self
             session.activate()
-            print("📱 iOS: WatchConnectivity activated")
+            #if DEBUG
+            print("iOS: WatchConnectivity activated")
+            #endif
         }
     }
-    
+
     func sendAuthToken(_ token: String) {
         guard WCSession.default.isReachable else {
             // Try transferring user info for background sync
             let userInfo = ["auth_token": token]
             WCSession.default.transferUserInfo(userInfo)
-            print("📱 iOS: Sent auth token via transferUserInfo")
             return
         }
-        
+
         let message = ["auth_token": token]
-        WCSession.default.sendMessage(message, replyHandler: { reply in
-            print("📱 iOS: Watch received auth token successfully")
+        WCSession.default.sendMessage(message, replyHandler: { _ in
         }, errorHandler: { error in
-            print("📱 iOS: Failed to send auth token to Watch: \(error)")
+            #if DEBUG
+            print("iOS: Failed to send auth token to Watch: \(error)")
+            #endif
         })
     }
-    
+
     func sendProjectsData(_ projects: [Project]) {
         let projectsData = projects.map { project in
             [
@@ -43,12 +45,11 @@ class WatchConnectivityService: NSObject, ObservableObject {
                 "color": project.color ?? "#3B82F6"
             ]
         }
-        
+
         let userInfo = ["projects": projectsData]
         WCSession.default.transferUserInfo(userInfo)
-        print("📱 iOS: Sent \(projects.count) projects to Watch")
     }
-    
+
     func sendDashboardData(earnings: Double, isRunning: Bool, todaysHours: Double, currentProject: String) {
         let dashboardData: [String: Any] = [
             "current_earnings": earnings,
@@ -59,7 +60,6 @@ class WatchConnectivityService: NSObject, ObservableObject {
 
         let userInfo = ["dashboard": dashboardData]
         WCSession.default.transferUserInfo(userInfo)
-        print("📱 iOS: Sent dashboard data to Watch")
     }
 
     /// Push the current timer state to the watch immediately via applicationContext.
@@ -81,12 +81,16 @@ class WatchConnectivityService: NSObject, ObservableObject {
 
         do {
             try WCSession.default.updateApplicationContext(context)
-            print("📱 iOS: Sent timer state to Watch (running: \(isRunning))")
+            #if DEBUG
+            print("iOS: Sent timer state to Watch (running: \(isRunning))")
+            #endif
         } catch {
-            print("📱 iOS: Failed to send timer state: \(error)")
+            #if DEBUG
+            print("iOS: Failed to send timer state: \(error)")
+            #endif
         }
     }
-    
+
     func sendRecentEntries(_ entries: [TimeEntry]) {
         let entriesData = entries.map { entry in
             [
@@ -98,35 +102,34 @@ class WatchConnectivityService: NSObject, ObservableObject {
                 "start_time": entry.startTime
             ]
         }
-        
+
         let userInfo = ["recent_entries": entriesData]
         WCSession.default.transferUserInfo(userInfo)
-        print("📱 iOS: Sent \(entries.count) recent entries to Watch")
     }
 }
 
 extension WatchConnectivityService: WCSessionDelegate {
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        #if DEBUG
         if let error = error {
-            print("📱 iOS: WatchConnectivity activation failed: \(error)")
-        } else {
-            print("📱 iOS: WatchConnectivity activated successfully")
+            print("iOS: WatchConnectivity activation failed: \(error)")
         }
+        #endif
     }
-    
+
     func sessionDidBecomeInactive(_ session: WCSession) {
-        print("📱 iOS: WatchConnectivity became inactive")
     }
-    
+
     func sessionDidDeactivate(_ session: WCSession) {
-        print("📱 iOS: WatchConnectivity deactivated")
         WCSession.default.activate()
     }
-    
+
     func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
-        print("📱 iOS: Received message from Watch: \(message)")
-        
-        if message["request"] as? String == "start_timer", 
+        #if DEBUG
+        print("iOS: Received message from Watch: \(message)")
+        #endif
+
+        if message["request"] as? String == "start_timer",
            let projectId = message["project_id"] as? String {
             // Handle start timer request from Watch
             // You would integrate this with your existing timer logic

--- a/packages/ios-app/Timetrack/Timetrack/Services/WatchConnectivityService.swift
+++ b/packages/ios-app/Timetrack/Timetrack/Services/WatchConnectivityService.swift
@@ -1,0 +1,141 @@
+import Foundation
+import WatchConnectivity
+
+class WatchConnectivityService: NSObject, ObservableObject {
+    static let shared = WatchConnectivityService()
+    
+    private override init() {
+        super.init()
+        setupWatchConnectivity()
+    }
+    
+    private func setupWatchConnectivity() {
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+            print("📱 iOS: WatchConnectivity activated")
+        }
+    }
+    
+    func sendAuthToken(_ token: String) {
+        guard WCSession.default.isReachable else {
+            // Try transferring user info for background sync
+            let userInfo = ["auth_token": token]
+            WCSession.default.transferUserInfo(userInfo)
+            print("📱 iOS: Sent auth token via transferUserInfo")
+            return
+        }
+        
+        let message = ["auth_token": token]
+        WCSession.default.sendMessage(message, replyHandler: { reply in
+            print("📱 iOS: Watch received auth token successfully")
+        }, errorHandler: { error in
+            print("📱 iOS: Failed to send auth token to Watch: \(error)")
+        })
+    }
+    
+    func sendProjectsData(_ projects: [Project]) {
+        let projectsData = projects.map { project in
+            [
+                "id": project.id,
+                "name": project.name,
+                "color": project.color ?? "#3B82F6"
+            ]
+        }
+        
+        let userInfo = ["projects": projectsData]
+        WCSession.default.transferUserInfo(userInfo)
+        print("📱 iOS: Sent \(projects.count) projects to Watch")
+    }
+    
+    func sendDashboardData(earnings: Double, isRunning: Bool, todaysHours: Double, currentProject: String) {
+        let dashboardData: [String: Any] = [
+            "current_earnings": earnings,
+            "is_timer_running": isRunning,
+            "todays_hours": todaysHours,
+            "current_project": currentProject
+        ]
+
+        let userInfo = ["dashboard": dashboardData]
+        WCSession.default.transferUserInfo(userInfo)
+        print("📱 iOS: Sent dashboard data to Watch")
+    }
+
+    /// Push the current timer state to the watch immediately via applicationContext.
+    /// Unlike transferUserInfo, applicationContext always overwrites the previous
+    /// value so the watch always sees the latest state.
+    func sendTimerState(isRunning: Bool, projectName: String, startTime: String?, entryId: String?) {
+        guard WCSession.default.activationState == .activated else { return }
+
+        var context: [String: Any] = [
+            "is_timer_running": isRunning,
+            "current_project": projectName
+        ]
+        if let startTime = startTime {
+            context["start_time"] = startTime
+        }
+        if let entryId = entryId {
+            context["entry_id"] = entryId
+        }
+
+        do {
+            try WCSession.default.updateApplicationContext(context)
+            print("📱 iOS: Sent timer state to Watch (running: \(isRunning))")
+        } catch {
+            print("📱 iOS: Failed to send timer state: \(error)")
+        }
+    }
+    
+    func sendRecentEntries(_ entries: [TimeEntry]) {
+        let entriesData = entries.map { entry in
+            [
+                "id": entry.id,
+                "project_name": entry.project?.name ?? "Unknown Project",
+                "task_name": entry.task?.name ?? "",
+                "duration": entry.safeDuration,
+                "hourly_rate": entry.hourlyRateSnapshot ?? 0.0,
+                "start_time": entry.startTime
+            ]
+        }
+        
+        let userInfo = ["recent_entries": entriesData]
+        WCSession.default.transferUserInfo(userInfo)
+        print("📱 iOS: Sent \(entries.count) recent entries to Watch")
+    }
+}
+
+extension WatchConnectivityService: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("📱 iOS: WatchConnectivity activation failed: \(error)")
+        } else {
+            print("📱 iOS: WatchConnectivity activated successfully")
+        }
+    }
+    
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        print("📱 iOS: WatchConnectivity became inactive")
+    }
+    
+    func sessionDidDeactivate(_ session: WCSession) {
+        print("📱 iOS: WatchConnectivity deactivated")
+        WCSession.default.activate()
+    }
+    
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
+        print("📱 iOS: Received message from Watch: \(message)")
+        
+        if message["request"] as? String == "start_timer", 
+           let projectId = message["project_id"] as? String {
+            // Handle start timer request from Watch
+            // You would integrate this with your existing timer logic
+            replyHandler(["status": "started"])
+        } else if message["request"] as? String == "stop_timer" {
+            // Handle stop timer request from Watch
+            replyHandler(["status": "stopped"])
+        } else {
+            replyHandler(["status": "unknown_request"])
+        }
+    }
+}

--- a/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
+++ b/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
@@ -188,6 +188,9 @@ class TimerViewModel: ObservableObject {
             // Start Live Activity
             await LiveActivityManager.shared.startActivity(entry: entry)
 
+            // Notify watch of timer start
+            notifyWatch()
+
             // Refresh recent entries
             await loadRecentEntries()
 
@@ -213,6 +216,9 @@ class TimerViewModel: ObservableObject {
             // Stop Live Activity
             await LiveActivityManager.shared.stopActivity()
 
+            // Notify watch of timer stop
+            notifyWatch()
+
             // Refresh recent entries
             await loadRecentEntries()
 
@@ -234,9 +240,7 @@ class TimerViewModel: ObservableObject {
     // MARK: - Elapsed Time Management
     private func calculateElapsedTime(from startTimeString: String) {
         guard let startTime = DateUtils.parseISO8601(startTimeString) else {
-            #if DEBUG
-            print("Failed to parse start time: \(startTimeString)")
-            #endif
+            print("❌ Failed to parse start time: \(startTimeString)")
             elapsedTime = 0
             return
         }
@@ -334,6 +338,19 @@ class TimerViewModel: ObservableObject {
 
     func clearError() {
         errorMessage = nil
+    }
+
+    // MARK: - Watch Sync
+    private func notifyWatch() {
+        let projectName = currentEntry?.project?.name ?? ""
+        let startTime = currentEntry?.startTime
+        let entryId = currentEntry?.id
+        WatchConnectivityService.shared.sendTimerState(
+            isRunning: isRunning,
+            projectName: projectName,
+            startTime: startTime,
+            entryId: entryId
+        )
     }
 
     // MARK: - Auto Refresh Setup
@@ -553,6 +570,8 @@ class TimerViewModel: ObservableObject {
                 await LiveActivityManager.shared.startActivity(entry: entry)
             }
         }
+
+        notifyWatch()
     }
 
     private func handleRemoteTimerStopped(_ entry: TimeEntry) {
@@ -569,6 +588,8 @@ class TimerViewModel: ObservableObject {
                 await LiveActivityManager.shared.stopActivity()
             }
         }
+
+        notifyWatch()
 
         // Refresh recent entries list
         Task {
@@ -737,3 +758,86 @@ class TimerViewModel: ObservableObject {
         }
     }
 }
+
+// MARK: - Premium App Theme
+struct AppTheme {
+    // Core colors - Rich, premium dark palette
+    static let primary = Color(hex: "#F8FAFC") ?? .white
+    static let secondary = Color(hex: "#94A3B8") ?? .secondary
+    static let tertiary = Color(hex: "#64748B") ?? .gray
+
+    // Accent colors - Vibrant gradient-ready
+    static let accent = Color(hex: "#6366F1") ?? .blue  // Indigo
+    static let accentSecondary = Color(hex: "#8B5CF6") ?? .purple  // Violet
+
+    // Backgrounds - Original dark palette
+    static let background = Color(hex: "#161516") ?? .black
+    static let backgroundElevated = Color(hex: "#1A1A1A") ?? .black
+    static let cardBackground = Color(hex: "#1F1F1F") ?? .gray
+    static let cardBackgroundHover = Color(hex: "#2A2A2A") ?? .gray
+
+    // Semantic colors - Rich and bold
+    static let success = Color(hex: "#22C55E") ?? .green
+    static let successMuted = Color(hex: "#16A34A") ?? .green
+    static let error = Color(hex: "#F43F5E") ?? .red  // Rose for premium feel
+    static let errorMuted = Color(hex: "#E11D48") ?? .red
+    static let warning = Color(hex: "#F59E0B") ?? .orange
+
+    // Earnings highlight - Green for live money display
+    static let earnings = Color(hex: "#22C55E") ?? .green
+    static let earningsMuted = Color(hex: "#16A34A") ?? .green
+
+    // Border colors
+    static let border = Color(hex: "#27272A") ?? .gray
+    static let borderSubtle = Color(hex: "#1F1F23") ?? .gray
+    static let borderAccent = (Color(hex: "#6366F1") ?? .blue).opacity(0.3)
+
+    // Gradients
+    static let accentGradient = LinearGradient(
+        colors: [Color(hex: "#6366F1") ?? .blue, Color(hex: "#8B5CF6") ?? .purple],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let successGradient = LinearGradient(
+        colors: [Color(hex: "#22C55E") ?? .green, Color(hex: "#10B981") ?? .green],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let errorGradient = LinearGradient(
+        colors: [Color(hex: "#F43F5E") ?? .red, Color(hex: "#E11D48") ?? .red],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let cardGradient = LinearGradient(
+        colors: [Color(hex: "#18181B") ?? .gray, Color(hex: "#111113") ?? .black],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    // Typography weights
+    static let fontWeightLight: Font.Weight = .light
+    static let fontWeightRegular: Font.Weight = .regular
+    static let fontWeightMedium: Font.Weight = .medium
+    static let fontWeightSemibold: Font.Weight = .semibold
+    static let fontWeightBold: Font.Weight = .bold
+
+    // Spacing system
+    static let spacingXS: CGFloat = 4
+    static let spacingSM: CGFloat = 8
+    static let spacingMD: CGFloat = 12
+    static let spacingLG: CGFloat = 16
+    static let spacingXL: CGFloat = 24
+    static let spacing2XL: CGFloat = 32
+
+    // Border radius
+    static let radiusSM: CGFloat = 6
+    static let radiusMD: CGFloat = 10
+    static let radiusLG: CGFloat = 14
+    static let radiusXL: CGFloat = 20
+    static let radiusFull: CGFloat = 100
+}
+
+// Color(hex:) extension is in Extensions/Color+Hex.swift

--- a/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
+++ b/packages/ios-app/Timetrack/Timetrack/ViewModels/TimerViewModel.swift
@@ -240,7 +240,9 @@ class TimerViewModel: ObservableObject {
     // MARK: - Elapsed Time Management
     private func calculateElapsedTime(from startTimeString: String) {
         guard let startTime = DateUtils.parseISO8601(startTimeString) else {
-            print("❌ Failed to parse start time: \(startTimeString)")
+            #if DEBUG
+            print("Failed to parse start time: \(startTimeString)")
+            #endif
             elapsedTime = 0
             return
         }
@@ -758,86 +760,3 @@ class TimerViewModel: ObservableObject {
         }
     }
 }
-
-// MARK: - Premium App Theme
-struct AppTheme {
-    // Core colors - Rich, premium dark palette
-    static let primary = Color(hex: "#F8FAFC") ?? .white
-    static let secondary = Color(hex: "#94A3B8") ?? .secondary
-    static let tertiary = Color(hex: "#64748B") ?? .gray
-
-    // Accent colors - Vibrant gradient-ready
-    static let accent = Color(hex: "#6366F1") ?? .blue  // Indigo
-    static let accentSecondary = Color(hex: "#8B5CF6") ?? .purple  // Violet
-
-    // Backgrounds - Original dark palette
-    static let background = Color(hex: "#161516") ?? .black
-    static let backgroundElevated = Color(hex: "#1A1A1A") ?? .black
-    static let cardBackground = Color(hex: "#1F1F1F") ?? .gray
-    static let cardBackgroundHover = Color(hex: "#2A2A2A") ?? .gray
-
-    // Semantic colors - Rich and bold
-    static let success = Color(hex: "#22C55E") ?? .green
-    static let successMuted = Color(hex: "#16A34A") ?? .green
-    static let error = Color(hex: "#F43F5E") ?? .red  // Rose for premium feel
-    static let errorMuted = Color(hex: "#E11D48") ?? .red
-    static let warning = Color(hex: "#F59E0B") ?? .orange
-
-    // Earnings highlight - Green for live money display
-    static let earnings = Color(hex: "#22C55E") ?? .green
-    static let earningsMuted = Color(hex: "#16A34A") ?? .green
-
-    // Border colors
-    static let border = Color(hex: "#27272A") ?? .gray
-    static let borderSubtle = Color(hex: "#1F1F23") ?? .gray
-    static let borderAccent = (Color(hex: "#6366F1") ?? .blue).opacity(0.3)
-
-    // Gradients
-    static let accentGradient = LinearGradient(
-        colors: [Color(hex: "#6366F1") ?? .blue, Color(hex: "#8B5CF6") ?? .purple],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
-
-    static let successGradient = LinearGradient(
-        colors: [Color(hex: "#22C55E") ?? .green, Color(hex: "#10B981") ?? .green],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
-
-    static let errorGradient = LinearGradient(
-        colors: [Color(hex: "#F43F5E") ?? .red, Color(hex: "#E11D48") ?? .red],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
-
-    static let cardGradient = LinearGradient(
-        colors: [Color(hex: "#18181B") ?? .gray, Color(hex: "#111113") ?? .black],
-        startPoint: .top,
-        endPoint: .bottom
-    )
-
-    // Typography weights
-    static let fontWeightLight: Font.Weight = .light
-    static let fontWeightRegular: Font.Weight = .regular
-    static let fontWeightMedium: Font.Weight = .medium
-    static let fontWeightSemibold: Font.Weight = .semibold
-    static let fontWeightBold: Font.Weight = .bold
-
-    // Spacing system
-    static let spacingXS: CGFloat = 4
-    static let spacingSM: CGFloat = 8
-    static let spacingMD: CGFloat = 12
-    static let spacingLG: CGFloat = 16
-    static let spacingXL: CGFloat = 24
-    static let spacing2XL: CGFloat = 32
-
-    // Border radius
-    static let radiusSM: CGFloat = 6
-    static let radiusMD: CGFloat = 10
-    static let radiusLG: CGFloat = 14
-    static let radiusXL: CGFloat = 20
-    static let radiusFull: CGFloat = 100
-}
-
-// Color(hex:) extension is in Extensions/Color+Hex.swift


### PR DESCRIPTION
## Summary
- Adds `sendTimerState()` to `WatchConnectivityService` using `updateApplicationContext` for instant latest-state delivery to the watch (avoids stale queued updates from `transferUserInfo`)
- Adds `notifyWatch()` helper to `TimerViewModel`, called on timer start, stop, and remote timer events
- Adds `didReceiveApplicationContext` delegate handler in watch `WatchConnectivityManager` to update UI when timer state arrives
- Loads pending `receivedApplicationContext` on watch app startup so state is picked up even if the watch launches after the iPhone sent an update

## Test plan
- [ ] Start a timer on the iPhone — watch should show the running project name
- [ ] Stop the timer on the iPhone — watch should reset to "No Active Project"
- [ ] Start a timer from another client (web/mac) — watch should update via remote timer event
- [ ] Kill and relaunch the watch app while a timer is running — it should pick up the current state on startup