### PR TITLE
Add multi-agent section to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,11 +208,14 @@ DerivedData/
 timeline.xctimeline
 playground.xcworkspace
 .build/
-.worktrees
 
-# Local dev artifacts
+# Claude Code / multi-agent
+.claude/worktrees/
+.worktrees/
 plans/
 todos/
+
+# Local dev artifacts
 *.png
 *.jpg
 *.gif


### PR DESCRIPTION
## Summary
- Organizes multi-agent and Claude Code artifacts into a dedicated `.gitignore` section
- Adds `.claude/worktrees/` for Claude Code worktree isolation directories
- Moves `.worktrees/`, `plans/`, and `todos/` under the new section (previously scattered or missing trailing slashes)

## Test plan
- [x] Verify `.gitignore` syntax is valid
- [x] Confirm no tracked files are affected