### PR TITLE
Clean up .gitignore to match actual project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-lerna-debug.log*
 .pnpm-debug.log*
 
 # Runtime data
@@ -12,114 +11,39 @@ pids
 *.seed
 *.pid.lock
 
-# Coverage directory used by tools like istanbul
+# Test coverage
 coverage/
 *.lcov
-
-# nyc test coverage
 .nyc_output
-
-# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-
-# Bower dependency directory (https://bower.io/)
-bower_components
-
-# node-waf configuration
-.lock-wscript
-
-# Compiled binary addons (https://nodejs.org/api/addons.html)
-build/Release
-
-# Dependency directories
-jspm_packages/
-
-# Snowpack dependency directory (https://snowpack.dev/)
-web_modules/
 
 # TypeScript cache
 *.tsbuildinfo
 
-# Optional npm cache directory
+# npm
 .npm
-
-# Optional eslint cache
 .eslintcache
-
-# Optional stylelint cache
 .stylelintcache
 
-# Microbundle cache
-.rpt2_cache/
-.rts2_cache_cjs/
-.rts2_cache_es/
-.rts2_cache_umd/
-
-# Optional REPL history
+# REPL history
 .node_repl_history
 
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
+# Yarn
 .yarn-integrity
-
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
-
-# parcel-bundler cache (https://parceljs.org/)
-.cache
-.parcel-cache
-
-# Next.js build output
-.next
-out
-
-# Nuxt.js build / generate output
-.nuxt
-dist
-
-# Gatsby files
-.cache/
-# Comment in the public line in if your project uses Gatsby and not Next.js
-# https://nextjs.org/blog/next-9-1#public-directory-support
-# public
-
-# vuepress build output
-.vuepress/dist
-
-# vuepress v2.x temp and cache directory
-.temp
-.cache
-
-# Docusaurus cache and generated files
-.docusaurus
-
-# Serverless directories
-.serverless/
-
-# FuseBox cache
-.fusebox/
-
-# DynamoDB Local files
-.dynamodb/
-
-# TernJS port file
-.tern-port
-
-# Stores VSCode versions used for testing VSCode extensions
-.vscode-test
-
-# yarn v2
 .yarn/cache
 .yarn/unplugged
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# dotenv environment variable files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Build outputs
 build/
@@ -156,29 +80,18 @@ logs
 tmp/
 temp/
 
-# Package manager lock files (keep package-lock.json but ignore others if using multiple managers)
-# yarn.lock
-# pnpm-lock.yaml
-
-# Local development files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
 # API specific
 uploads/
 storage/
 
-# UI specific (Vite/React)
-# dist already covered above
+# UI specific (Vite/React/Electron)
 .vite/
 
-# Docker specific
+# Docker
 docker.env
 *.sql
 backup_*.sql
-# Allow specific SQL files needed for initialization and migrations
+# Allow SQL files needed for initialization and migrations
 !*/init.sql
 !init.sql
 !*/migrations/*/migration.sql
@@ -209,14 +122,20 @@ timeline.xctimeline
 playground.xcworkspace
 .build/
 
+# Xcode build artifacts (iOS/macOS/watchOS)
+build-*/
+**/SourcePackages/
+**/Index.noindex/
+**/CompilationCache.noindex/
+**/ModuleCache.noindex/
+**/SDKStatCaches.noindex/
+
 # Claude Code / multi-agent
 .claude/worktrees/
 .worktrees/
+.playwright-mcp/
 plans/
 todos/
 
 # Local dev artifacts
-*.png
-*.jpg
-*.gif
 github_key_id_*


### PR DESCRIPTION
## Summary
- Remove ~15 irrelevant framework entries (Grunt, Bower, JSPM, Snowpack, Next.js, Nuxt, Gatsby, VuePress, Docusaurus, Serverless, FuseBox, DynamoDB, TernJS, Microbundle, Lerna, Parcel) — none of these are used in this project
- Add missing Xcode build patterns (`build-*/`, `SourcePackages/`, `.noindex` caches) that were generating untracked files
- Add `.playwright-mcp/` for browser automation logs
- Remove overly broad `*.png`/`*.jpg`/`*.gif` that could block legitimate app icon assets
- Remove duplicate `.env` entries (were listed in two separate sections)
- Net result: **-103 lines, +22 lines** — much leaner and actually matches what we use

## Test plan
- [x] `git status` shows only `.gitignore` modified — no tracked files lost
- [x] Previously untracked `build-watch/` and `SourcePackages/` are now properly ignored
- [x] Tracked image files (app icons in xcassets, landing page assets) remain tracked