### PR TITLE
Add staging environment indicator to sidebar

### DIFF
--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -20,6 +20,10 @@ const navigation = [
   { name: "API Test", href: "/api-test", icon: WrenchScrewdriverIcon },
 ];
 
+const isStaging = ((import.meta as any).env.VITE_API_URL || "").includes(
+  "staging"
+);
+
 const Sidebar: React.FC = () => {
   const location = useLocation();
   const { user } = useSelector((state: RootState) => state.auth);
@@ -30,6 +34,13 @@ const Sidebar: React.FC = () => {
       <div className="flex items-center justify-center h-16 px-4 border-b border-gray-200">
         <h1 className="text-xl font-bold text-primary-600">TimeTrack</h1>
       </div>
+
+      {/* Staging indicator */}
+      {isStaging && (
+        <div className="bg-yellow-400 text-yellow-900 text-center text-xs font-bold py-1 tracking-widest uppercase">
+          Staging
+        </div>
+      )}
 
       {/* Navigation */}
       <nav className="flex-1 px-4 py-6 space-y-1">


### PR DESCRIPTION
## Summary
Added a visual indicator to the sidebar that displays when the application is running in a staging environment, helping users quickly identify which environment they're working in.

## Changes
- Added environment detection logic that checks if the `VITE_API_URL` contains "staging"
- Added a prominent yellow banner to the sidebar that displays "Staging" text when in staging environment
- The indicator appears below the TimeTrack logo and above the navigation menu
- Styled with yellow background, bold uppercase text, and wide letter spacing for high visibility

## Implementation Details
- Environment detection is performed at module load time using `import.meta.env.VITE_API_URL`
- The staging indicator is conditionally rendered only when the staging environment is detected
- Uses Tailwind CSS classes for styling (`bg-yellow-400`, `text-yellow-900`) to ensure clear visual distinction from production

https://claude.ai/code/session_016FXgbosSBGsbTKKAwQNjw6