### PR TITLE
Fix staging deploy workflow PR comment permissions

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled, synchronize, unlabeled, closed]
 
+permissions:
+  pull-requests: write
+
 concurrency:
   group: staging-deploy
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Adds `permissions: pull-requests: write` to the staging deploy workflow
- The default GITHUB_TOKEN doesn't have write access to PRs, causing a 403 when commenting staging URLs

## Test plan
- [ ] Merge this, add `deploy-staging` label to a PR, verify the comment is posted