### PR TITLE
Make sign-up link URL configurable via environment variable

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,6 +115,7 @@ services:
       target: production
       args:
         PUBLIC_URL: "/"
+        VITE_APP_URL: "${VITE_APP_URL:-https://app.track.alfredo.re}"
     container_name: timetrack-landing-prod
     restart: unless-stopped
     environment:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -108,6 +108,7 @@ services:
       target: production
       args:
         PUBLIC_URL: "/"
+        VITE_APP_URL: "${VITE_APP_URL:-https://app.staging.track.alfredo.re}"
     container_name: timetrack-landing-staging
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
     restart: unless-stopped
     environment:
       PUBLIC_URL: "/"
+      VITE_APP_URL: "${VITE_APP_URL:-http://localhost:3010}"
     ports:
       - "${LANDING_PORT:-3014}:5174"
     networks:

--- a/docker.env.example
+++ b/docker.env.example
@@ -36,6 +36,7 @@ ALLOWED_ORIGINS=http://localhost:3010,https://yourdomain.com
 # Only needed for local development — in production the UI's nginx
 # reverse-proxies /api/ to the API container automatically.
 VITE_API_URL=http://localhost:3011
+VITE_APP_URL=http://localhost:3010
 
 # Redis Configuration
 REDIS_PASSWORD=redis_secure_password
@@ -60,6 +61,7 @@ REDIS_PASSWORD=redis_secure_password
 
 # Production URLs - update with your actual domain
 # ALLOWED_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
+# VITE_APP_URL=https://app.yourdomain.com
 # APPLICATION_URL=https://app.yourdomain.com
 # NOTE: VITE_API_URL is NOT needed for production — nginx proxies /api/ to the API
 

--- a/docker.staging.env.example
+++ b/docker.staging.env.example
@@ -35,6 +35,7 @@ ALLOWED_ORIGINS=https://staging.track.alfredo.re,https://app.staging.track.alfre
 
 # Vite Environment Variables (exposed to frontend)
 VITE_API_URL=https://api.staging.track.alfredo.re
+VITE_APP_URL=https://app.staging.track.alfredo.re
 
 # Application URL (used by API for links, emails, etc.)
 APPLICATION_URL=https://app.staging.track.alfredo.re

--- a/packages/landing/Dockerfile
+++ b/packages/landing/Dockerfile
@@ -7,6 +7,10 @@ FROM node:18-alpine AS build
 ARG PUBLIC_URL
 ENV PUBLIC_URL=${PUBLIC_URL:-/}
 
+# App URL for sign-up link (environment-specific)
+ARG VITE_APP_URL
+ENV VITE_APP_URL=${VITE_APP_URL}
+
 WORKDIR /app
 
 # Copy workspace package manifests so npm can resolve deps

--- a/packages/landing/src/components/Hero.tsx
+++ b/packages/landing/src/components/Hero.tsx
@@ -45,7 +45,7 @@ const Hero: React.FC = () => {
           {downloadLabel}
         </a>
         <a
-          href="https://app.track.alfredo.re"
+          href={import.meta.env.VITE_APP_URL || "/"}
           className="inline-block border border-neon-purple px-8 py-3 rounded-md font-semibold text-neon-purple hover:bg-neon-purple hover:text-white transition-colors"
         >
           {signUpLabel}


### PR DESCRIPTION
## Summary
This PR makes the sign-up link URL in the landing page configurable through the `VITE_APP_URL` environment variable, replacing the hardcoded URL. This allows different deployment environments (local, staging, production) to point to their respective application URLs.

## Key Changes
- **Hero component**: Updated the sign-up link to use `import.meta.env.VITE_APP_URL` instead of hardcoded `https://app.track.alfredo.re`
- **Dockerfile**: Added `VITE_APP_URL` build argument and environment variable configuration
- **Docker Compose files**: Added `VITE_APP_URL` environment variable with environment-specific defaults:
  - Local development: `http://localhost:3010`
  - Staging: `https://app.staging.track.alfredo.re`
  - Production: `https://app.track.alfredo.re`
- **Environment examples**: Updated all `.env.example` files to include `VITE_APP_URL` configuration with documentation

## Implementation Details
- The environment variable is passed as a build argument to the Docker build process and exposed to the frontend via Vite's `import.meta.env`
- Each deployment environment (local, staging, production) has appropriate default values
- Falls back to `/` if the environment variable is not set, ensuring the link remains functional