### PR TITLE
Fix staging deploy failing when PR branch already checked out

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,8 +31,8 @@ jobs:
             cd ~/websites/timetrack-monorepo
 
             echo "=== Fetching PR #${{ github.event.pull_request.number }} ==="
-            git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
-            git checkout pr-${{ github.event.pull_request.number }}
+            git fetch origin pull/${{ github.event.pull_request.number }}/head
+            git checkout -B pr-${{ github.event.pull_request.number }} FETCH_HEAD
 
             echo "=== Cleaning up Docker to free disk space ==="
             docker image prune -f


### PR DESCRIPTION
## Summary
- `git fetch origin pull/N/head:pr-N` fails when `pr-N` is already checked out
- Changed to fetch to FETCH_HEAD, then `checkout -B` to force-update the local branch

## Test plan
- [ ] Merge, add `deploy-staging` label to PR #96, verify deploy succeeds