### PR TITLE
Fix favorites feature issues from code review

### DIFF
--- a/packages/api/prisma/migrations/20260303000000_favorite_task_set_null/migration.sql
+++ b/packages/api/prisma/migrations/20260303000000_favorite_task_set_null/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: Change favorites.taskId FK from CASCADE to SET NULL on delete
+ALTER TABLE "favorites" DROP CONSTRAINT "favorites_taskId_fkey";
+ALTER TABLE "favorites" ADD CONSTRAINT "favorites_taskId_fkey"
+  FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -138,7 +138,7 @@ model Favorite {
   projectId String
   project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   taskId    String?
-  task      Task?    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task      Task?    @relation(fields: [taskId], references: [id], onDelete: SetNull)
 
   @@unique([userId, projectId, taskId, description], name: "unique_favorite")
   @@map("favorites")

--- a/packages/api/src/routes/favorites.ts
+++ b/packages/api/src/routes/favorites.ts
@@ -18,15 +18,6 @@ const createFavoriteSchema = z.object({
   description: z.string().max(200, "Description must be 200 characters or less").optional(),
 });
 
-const updateFavoriteSchema = z.object({
-  description: z.string().max(200, "Description must be 200 characters or less").optional(),
-  displayOrder: z.number().int().nonnegative().optional(),
-});
-
-const reorderFavoritesSchema = z.object({
-  orderedIds: z.array(z.string()).min(1, "At least one ID is required"),
-});
-
 // Select fields for consistent response shape
 const favoriteSelect = {
   id: true,
@@ -53,8 +44,16 @@ const favoriteSelect = {
 } as const;
 
 /**
- * GET /favorites
- * List all favorites for the authenticated user, ordered by displayOrder
+ * @swagger
+ * /favorites:
+ *   get:
+ *     summary: List all favorites for the authenticated user
+ *     tags: [Favorites]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Favorites retrieved successfully
  */
 router.get(
   "/",
@@ -70,8 +69,36 @@ router.get(
 );
 
 /**
- * POST /favorites
- * Create a new favorite
+ * @swagger
+ * /favorites:
+ *   post:
+ *     summary: Create a new favorite
+ *     tags: [Favorites]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - projectId
+ *             properties:
+ *               projectId:
+ *                 type: string
+ *               taskId:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *                 maxLength: 200
+ *     responses:
+ *       201:
+ *         description: Favorite created successfully
+ *       400:
+ *         description: Maximum favorites limit reached
+ *       409:
+ *         description: Duplicate favorite
  */
 router.post(
   "/",
@@ -80,14 +107,6 @@ router.post(
 
     // Normalize description
     const normalizedDescription = description?.trim() || null;
-
-    // Check limit
-    const count = await prisma.favorite.count({
-      where: { userId: req.user!.id },
-    });
-    if (count >= MAX_FAVORITES) {
-      throw createError("Maximum of 5 favorites allowed", 400);
-    }
 
     // Verify project exists and belongs to user
     const project = await prisma.project.findFirst({
@@ -107,35 +126,45 @@ router.post(
       }
     }
 
-    // Check for duplicate
-    const existing = await prisma.favorite.findFirst({
-      where: {
-        userId: req.user!.id,
-        projectId,
-        taskId: taskId || null,
-        description: normalizedDescription,
-      },
-    });
-    if (existing) {
-      throw createError("This combination is already a favorite", 409);
-    }
+    // Use transaction for atomicity (count check + create)
+    const favorite = await prisma.$transaction(async (tx: typeof prisma) => {
+      const count = await tx.favorite.count({
+        where: { userId: req.user!.id },
+      });
+      if (count >= MAX_FAVORITES) {
+        throw createError("Maximum of 5 favorites allowed", 400);
+      }
 
-    // Get next display order
-    const maxOrder = await prisma.favorite.aggregate({
-      where: { userId: req.user!.id },
-      _max: { displayOrder: true },
-    });
-    const nextOrder = (maxOrder._max.displayOrder ?? -1) + 1;
+      // Check for duplicate
+      const existing = await tx.favorite.findFirst({
+        where: {
+          userId: req.user!.id,
+          projectId,
+          taskId: taskId || null,
+          description: normalizedDescription,
+        },
+      });
+      if (existing) {
+        throw createError("This combination is already a favorite", 409);
+      }
 
-    const favorite = await prisma.favorite.create({
-      data: {
-        userId: req.user!.id,
-        projectId,
-        taskId: taskId || null,
-        description: normalizedDescription,
-        displayOrder: nextOrder,
-      },
-      select: favoriteSelect,
+      // Get next display order
+      const maxOrder = await tx.favorite.aggregate({
+        where: { userId: req.user!.id },
+        _max: { displayOrder: true },
+      });
+      const nextOrder = (maxOrder._max.displayOrder ?? -1) + 1;
+
+      return tx.favorite.create({
+        data: {
+          userId: req.user!.id,
+          projectId,
+          taskId: taskId || null,
+          description: normalizedDescription,
+          displayOrder: nextOrder,
+        },
+        select: favoriteSelect,
+      });
     });
 
     // Emit real-time update
@@ -150,121 +179,24 @@ router.post(
 );
 
 /**
- * PUT /favorites/reorder
- * Bulk reorder all favorites (must be before /:id route)
- */
-router.put(
-  "/reorder",
-  asyncHandler(async (req: AuthenticatedRequest, res) => {
-    const { orderedIds } = reorderFavoritesSchema.parse(req.body);
-
-    // Verify all IDs belong to the user
-    const userFavorites = await prisma.favorite.findMany({
-      where: { userId: req.user!.id },
-      select: { id: true },
-    });
-
-    const userFavoriteIds = new Set(userFavorites.map((f: { id: string }) => f.id));
-    const orderedIdSet = new Set(orderedIds);
-
-    // Check that the sets match exactly
-    if (orderedIds.length !== userFavorites.length) {
-      throw createError(
-        "orderedIds must contain exactly the same set of IDs as your current favorites",
-        400
-      );
-    }
-    for (const id of orderedIds) {
-      if (!userFavoriteIds.has(id)) {
-        throw createError(
-          "orderedIds must contain exactly the same set of IDs as your current favorites",
-          400
-        );
-      }
-    }
-    if (orderedIdSet.size !== orderedIds.length) {
-      throw createError("orderedIds must not contain duplicates", 400);
-    }
-
-    // Update all display orders atomically
-    await prisma.$transaction(
-      orderedIds.map((id, index) =>
-        prisma.favorite.update({
-          where: { id },
-          data: { displayOrder: index },
-        })
-      )
-    );
-
-    // Fetch updated favorites
-    const favorites = await prisma.favorite.findMany({
-      where: { userId: req.user!.id },
-      select: favoriteSelect,
-      orderBy: { displayOrder: "asc" },
-    });
-
-    // Emit real-time update
-    const io = req.app.get("io");
-    io.to(`user-${req.user!.id}`).emit("favorites-reordered", favorites);
-
-    res.json({
-      message: "Favorites reordered successfully",
-      favorites,
-    });
-  })
-);
-
-/**
- * PUT /favorites/:id
- * Update a single favorite
- */
-router.put(
-  "/:id",
-  asyncHandler(async (req: AuthenticatedRequest, res) => {
-    const { id } = req.params;
-    const updateData = updateFavoriteSchema.parse(req.body);
-
-    if (updateData.description === undefined && updateData.displayOrder === undefined) {
-      throw createError("At least one field must be provided", 400);
-    }
-
-    // Check ownership
-    const existing = await prisma.favorite.findFirst({
-      where: { id, userId: req.user!.id },
-    });
-    if (!existing) {
-      throw createError("Favorite not found", 404);
-    }
-
-    // Normalize description if provided
-    const data: any = {};
-    if (updateData.description !== undefined) {
-      data.description = updateData.description.trim() || null;
-    }
-    if (updateData.displayOrder !== undefined) {
-      data.displayOrder = updateData.displayOrder;
-    }
-
-    const favorite = await prisma.favorite.update({
-      where: { id },
-      data,
-      select: favoriteSelect,
-    });
-
-    // Emit real-time update
-    const io = req.app.get("io");
-    io.to(`user-${req.user!.id}`).emit("favorite-updated", favorite);
-
-    res.json({
-      message: "Favorite updated successfully",
-      favorite,
-    });
-  })
-);
-
-/**
- * DELETE /favorites/:id
- * Remove a favorite
+ * @swagger
+ * /favorites/{id}:
+ *   delete:
+ *     summary: Remove a favorite
+ *     tags: [Favorites]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Favorite deleted successfully
+ *       404:
+ *         description: Favorite not found
  */
 router.delete(
   "/:id",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -80,43 +80,6 @@ export interface PaginatedResponse<T> {
   totalPages: number;
 }
 
-// Favorite types
-export interface Favorite {
-  id: string;
-  displayOrder: number;
-  description?: string;
-  userId: string;
-  projectId: string;
-  taskId?: string;
-  project?: {
-    id: string;
-    name: string;
-    color: string;
-  };
-  task?: {
-    id: string;
-    name: string;
-  } | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface CreateFavoriteRequest {
-  projectId: string;
-  taskId?: string;
-  description?: string;
-  displayOrder?: number;
-}
-
-export interface UpdateFavoriteRequest {
-  description?: string;
-  displayOrder?: number;
-}
-
-export interface ReorderFavoritesRequest {
-  orderedIds: string[];
-}
-
 // Error types
 export interface ApiError {
   message: string;

--- a/packages/ui/src/components/AddFavoriteModal.tsx
+++ b/packages/ui/src/components/AddFavoriteModal.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { AppDispatch, RootState } from "../store";
 import { createFavorite } from "../store/slices/favoritesSlice";
-import { fetchProjects, fetchTasks } from "../store/slices/projectsSlice";
+import { fetchProjects, fetchTasks, Project, Task } from "../store/slices/projectsSlice";
 
 interface AddFavoriteModalProps {
   isOpen: boolean;
@@ -43,11 +43,11 @@ const AddFavoriteModal: React.FC<AddFavoriteModalProps> = ({
   }, [selectedProjectId, dispatch]);
 
   const activeProjects = Array.isArray(projects)
-    ? projects.filter((p: any) => p.isActive)
+    ? projects.filter((p: Project) => p.isActive)
     : [];
 
   const projectTasks = Array.isArray(tasks)
-    ? tasks.filter((t: any) => t.projectId === selectedProjectId)
+    ? tasks.filter((t: Task) => t.projectId === selectedProjectId)
     : [];
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -66,9 +66,10 @@ const AddFavoriteModal: React.FC<AddFavoriteModalProps> = ({
         })
       ).unwrap();
       onClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : null;
       setError(
-        err?.message || "Failed to create favorite. It may already exist."
+        message || "Failed to create favorite. It may already exist."
       );
     } finally {
       setSubmitting(false);
@@ -114,7 +115,7 @@ const AddFavoriteModal: React.FC<AddFavoriteModalProps> = ({
               className="input w-full"
             >
               <option value="">Select a project</option>
-              {activeProjects.map((project: any) => (
+              {activeProjects.map((project: Project) => (
                 <option key={project.id} value={project.id}>
                   {project.name}
                 </option>
@@ -138,7 +139,7 @@ const AddFavoriteModal: React.FC<AddFavoriteModalProps> = ({
                 className="input w-full"
               >
                 <option value="">No task</option>
-                {projectTasks.map((task: any) => (
+                {projectTasks.map((task: Task) => (
                   <option key={task.id} value={task.id}>
                     {task.name}
                   </option>

--- a/packages/ui/src/components/FavoriteButton.tsx
+++ b/packages/ui/src/components/FavoriteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { StarIcon as StarOutline } from "@heroicons/react/24/outline";
 import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
@@ -7,6 +7,7 @@ import {
   createFavorite,
   deleteFavorite,
   Favorite,
+  MAX_FAVORITES,
 } from "../store/slices/favoritesSlice";
 
 interface FavoriteButtonProps {
@@ -14,8 +15,6 @@ interface FavoriteButtonProps {
   taskId?: string | null;
   description?: string | null;
 }
-
-const MAX_FAVORITES = 5;
 
 const FavoriteButton: React.FC<FavoriteButtonProps> = ({
   projectId,
@@ -44,41 +43,29 @@ const FavoriteButton: React.FC<FavoriteButtonProps> = ({
   const isFavorited = !!matchingFavorite;
   const atLimit = favorites.length >= MAX_FAVORITES;
 
-  const handleClick = useCallback(
-    async (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (pending) return;
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (pending) return;
 
-      setPending(true);
-      try {
-        if (isFavorited && matchingFavorite) {
-          await dispatch(deleteFavorite(matchingFavorite.id)).unwrap();
-        } else if (!atLimit) {
-          await dispatch(
-            createFavorite({
-              projectId,
-              taskId: normalizedTaskId,
-              description: normalizedDescription,
-            })
-          ).unwrap();
-        }
-      } catch {
-        // Error handled by Redux
-      } finally {
-        setPending(false);
+    setPending(true);
+    try {
+      if (isFavorited && matchingFavorite) {
+        await dispatch(deleteFavorite(matchingFavorite.id)).unwrap();
+      } else if (!atLimit) {
+        await dispatch(
+          createFavorite({
+            projectId,
+            taskId: normalizedTaskId,
+            description: normalizedDescription,
+          })
+        ).unwrap();
       }
-    },
-    [
-      dispatch,
-      isFavorited,
-      matchingFavorite,
-      atLimit,
-      projectId,
-      normalizedTaskId,
-      normalizedDescription,
-      pending,
-    ]
-  );
+    } catch {
+      // Error handled by Redux
+    } finally {
+      setPending(false);
+    }
+  };
 
   const isDisabled = pending || (!isFavorited && atLimit);
 

--- a/packages/ui/src/components/FavoriteCard.tsx
+++ b/packages/ui/src/components/FavoriteCard.tsx
@@ -53,9 +53,7 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
       {/* Description */}
       {favorite.description && (
         <p className="text-xs text-gray-400 truncate mt-0.5">
-          {favorite.description.length > 25
-            ? `${favorite.description.substring(0, 25)}...`
-            : favorite.description}
+          {favorite.description}
         </p>
       )}
 

--- a/packages/ui/src/components/FavoritesBar.tsx
+++ b/packages/ui/src/components/FavoritesBar.tsx
@@ -7,12 +7,11 @@ import {
   fetchFavorites,
   deleteFavorite,
   Favorite,
+  MAX_FAVORITES,
 } from "../store/slices/favoritesSlice";
 import { useTimer } from "../hooks/useTimer";
 import FavoriteCard from "./FavoriteCard";
 import AddFavoriteModal from "./AddFavoriteModal";
-
-const MAX_FAVORITES = 5;
 
 const FavoritesBar: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();

--- a/packages/ui/src/hooks/useSocket.ts
+++ b/packages/ui/src/hooks/useSocket.ts
@@ -23,8 +23,6 @@ import { fetchDashboardEarnings } from "../store/slices/dashboardSlice";
 import {
   favoriteCreatedFromSocket,
   favoriteDeletedFromSocket,
-  favoriteUpdatedFromSocket,
-  favoritesReorderedFromSocket,
 } from "../store/slices/favoritesSlice";
 
 export function useSocket() {
@@ -119,12 +117,6 @@ export function useSocket() {
       },
       onFavoriteDeleted: (data) => {
         dispatch(favoriteDeletedFromSocket(data));
-      },
-      onFavoriteUpdated: (favorite) => {
-        dispatch(favoriteUpdatedFromSocket(favorite));
-      },
-      onFavoritesReordered: (favorites) => {
-        dispatch(favoritesReorderedFromSocket(favorites));
       },
     });
 

--- a/packages/ui/src/pages/TimeEntries.tsx
+++ b/packages/ui/src/pages/TimeEntries.tsx
@@ -13,6 +13,7 @@ import EditTimeEntryModal from "../components/EditTimeEntryModal";
 import { formatReportsDuration, formatDateTime } from "../utils/dateTime";
 import { ClockIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { StopIcon } from "@heroicons/react/24/solid";
+import FavoriteButton from "../components/FavoriteButton";
 
 const TimeEntries: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -267,6 +268,13 @@ const TimeEntries: React.FC = () => {
                           <span className="text-sm text-gray-500">
                             • {entry.task.name}
                           </span>
+                        )}
+                        {entry.project && (
+                          <FavoriteButton
+                            projectId={entry.project.id}
+                            taskId={entry.task?.id}
+                            description={entry.description}
+                          />
                         )}
                         {isRunning && (
                           <div className="flex items-center space-x-2">

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from "axios";
 import { User } from "../store/slices/authSlice";
 import { Project, Task } from "../store/slices/projectsSlice";
 import { TimeEntry } from "../store/slices/timeEntriesSlice";
+import { Favorite } from "../store/slices/favoritesSlice";
 
 // In production the UI is served by nginx which reverse-proxies /api/ to the
 // API container, so no absolute URL is needed. VITE_API_URL is only required
@@ -462,7 +463,7 @@ class APIClient {
   // Favorites API
   favorites = {
     getFavorites: async () => {
-      const response = await this.request<{ favorites: any[] }>(
+      const response = await this.request<{ favorites: Favorite[] }>(
         "GET",
         "/favorites"
       );
@@ -476,7 +477,7 @@ class APIClient {
     }) => {
       const response = await this.request<{
         message: string;
-        favorite: any;
+        favorite: Favorite;
       }>("POST", "/favorites", data);
       return response.favorite;
     },
@@ -485,24 +486,6 @@ class APIClient {
       return this.request<{ message: string }>("DELETE", `/favorites/${id}`);
     },
 
-    updateFavorite: async (
-      id: string,
-      data: { description?: string; displayOrder?: number }
-    ) => {
-      const response = await this.request<{
-        message: string;
-        favorite: any;
-      }>("PUT", `/favorites/${id}`, data);
-      return response.favorite;
-    },
-
-    reorderFavorites: async (orderedIds: string[]) => {
-      const response = await this.request<{
-        message: string;
-        favorites: any[];
-      }>("PUT", "/favorites/reorder", { orderedIds });
-      return response.favorites;
-    },
   };
 
   // Health check

--- a/packages/ui/src/services/socket.ts
+++ b/packages/ui/src/services/socket.ts
@@ -35,8 +35,6 @@ interface SocketEventHandlers {
   // Favorite events
   onFavoriteCreated?: EventCallback<Favorite>;
   onFavoriteDeleted?: EventCallback<{ id: string }>;
-  onFavoriteUpdated?: EventCallback<Favorite>;
-  onFavoritesReordered?: EventCallback<Favorite[]>;
   // Connection events
   onConnectionStateChange?: EventCallback<ConnectionState>;
 }
@@ -195,15 +193,6 @@ class SocketService {
       this.handlers.onFavoriteDeleted?.(data);
     });
 
-    this.socket.on("favorite-updated", (data: Favorite) => {
-      console.log("[Socket] favorite-updated", data.id);
-      this.handlers.onFavoriteUpdated?.(data);
-    });
-
-    this.socket.on("favorites-reordered", (data: Favorite[]) => {
-      console.log("[Socket] favorites-reordered");
-      this.handlers.onFavoritesReordered?.(data);
-    });
   }
 
   private scheduleReconnect(): void {

--- a/packages/ui/src/store/slices/favoritesSlice.ts
+++ b/packages/ui/src/store/slices/favoritesSlice.ts
@@ -26,6 +26,8 @@ interface FavoritesState {
   error: string | null;
 }
 
+export const MAX_FAVORITES = 5;
+
 const initialState: FavoritesState = {
   favorites: [],
   loading: false,
@@ -61,28 +63,6 @@ export const deleteFavorite = createAsyncThunk(
   }
 );
 
-export const updateFavorite = createAsyncThunk(
-  "favorites/updateFavorite",
-  async ({
-    id,
-    data,
-  }: {
-    id: string;
-    data: { description?: string; displayOrder?: number };
-  }) => {
-    const response = await favoritesAPI.updateFavorite(id, data);
-    return response;
-  }
-);
-
-export const reorderFavorites = createAsyncThunk(
-  "favorites/reorderFavorites",
-  async (orderedIds: string[]) => {
-    const response = await favoritesAPI.reorderFavorites(orderedIds);
-    return response;
-  }
-);
-
 const favoritesSlice = createSlice({
   name: "favorites",
   initialState,
@@ -106,21 +86,6 @@ const favoritesSlice = createSlice({
         (f) => f.id !== action.payload.id
       );
     },
-    favoriteUpdatedFromSocket: (state, action: PayloadAction<Favorite>) => {
-      const index = state.favorites.findIndex(
-        (f) => f.id === action.payload.id
-      );
-      if (index !== -1) {
-        state.favorites[index] = action.payload;
-      }
-      state.favorites.sort((a, b) => a.displayOrder - b.displayOrder);
-    },
-    favoritesReorderedFromSocket: (
-      state,
-      action: PayloadAction<Favorite[]>
-    ) => {
-      state.favorites = action.payload;
-    },
   },
   extraReducers: (builder) => {
     builder
@@ -137,8 +102,10 @@ const favoritesSlice = createSlice({
         state.error = action.error.message || "Failed to fetch favorites";
       })
       .addCase(createFavorite.fulfilled, (state, action) => {
-        state.favorites.push(action.payload);
-        state.favorites.sort((a, b) => a.displayOrder - b.displayOrder);
+        if (!state.favorites.find((f) => f.id === action.payload.id)) {
+          state.favorites.push(action.payload);
+          state.favorites.sort((a, b) => a.displayOrder - b.displayOrder);
+        }
       })
       .addCase(createFavorite.rejected, (state, action) => {
         state.error = action.error.message || "Failed to create favorite";
@@ -148,18 +115,6 @@ const favoritesSlice = createSlice({
           (f) => f.id !== action.payload
         );
       })
-      .addCase(updateFavorite.fulfilled, (state, action) => {
-        const index = state.favorites.findIndex(
-          (f) => f.id === action.payload.id
-        );
-        if (index !== -1) {
-          state.favorites[index] = action.payload;
-        }
-        state.favorites.sort((a, b) => a.displayOrder - b.displayOrder);
-      })
-      .addCase(reorderFavorites.fulfilled, (state, action) => {
-        state.favorites = action.payload;
-      });
   },
 });
 
@@ -167,8 +122,6 @@ export const {
   clearError,
   favoriteCreatedFromSocket,
   favoriteDeletedFromSocket,
-  favoriteUpdatedFromSocket,
-  favoritesReorderedFromSocket,
 } = favoritesSlice.actions;
 
 export default favoritesSlice.reducer;


### PR DESCRIPTION
## Summary
Post-merge review fixes for the favorites feature (PR #95):

- **P1 Bug fix**: Duplicate favorite cards appearing on create (race between Redux thunk and Socket.IO event)
- **P2 Race safety**: Wrap POST /favorites in Prisma `$transaction` so count check + create are atomic
- **P2 FK behavior**: Change `Favorite.taskId` from `CASCADE` to `SET NULL` — deleting a task no longer silently removes favorites
- **P2 Type safety**: Replace all `any` types with proper types in API service, AddFavoriteModal, and slice
- **P2 DRY**: Centralize `MAX_FAVORITES` constant, remove duplicate `Favorite` interface from shared package
- **P3 Dead code**: Remove unused update/reorder endpoints and all related plumbing (routes, thunks, reducers, socket handlers, API methods, shared types)
- **P3 Cleanup**: Remove redundant manual string truncation, ineffective `useCallback`, add Swagger docs

## Test plan
- [ ] Create a favorite — verify no duplicate cards appear
- [ ] Hit the 5-favorite limit — verify error is returned atomically
- [ ] Delete a task that has an associated favorite — favorite should remain with `taskId: null`
- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit` for api and ui)
- [ ] Run the migration on staging/production