### PR TITLE
Build Docker services sequentially in prod/staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,7 +12,7 @@ jobs:
   deploy-pr:
     name: Deploy PR to Staging
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'deploy-staging') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-staging'))
@@ -24,7 +24,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 25m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
@@ -99,7 +99,7 @@ jobs:
   rollback:
     name: Roll Back Staging to Main
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     if: >-
       (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-staging') ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-staging'))
@@ -111,7 +111,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 25m
           script: |
             set -euo pipefail
             DEPLOY_DIR=~/websites/timetrack-staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Deploy via SSH
@@ -21,7 +21,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 25m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"

--- a/deploy.sh
+++ b/deploy.sh
@@ -197,7 +197,17 @@ deploy() {
     fi
 
     # Build and start services
-    docker_compose -f "$compose_file" up -d --build
+    # In prod/staging, build sequentially to avoid overwhelming the server
+    # when Docker cache is cold (parallel npm ci can exhaust CPU/RAM).
+    if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
+        log_info "Building services sequentially..."
+        docker_compose -f "$compose_file" build api
+        docker_compose -f "$compose_file" build web
+        docker_compose -f "$compose_file" build landing
+        docker_compose -f "$compose_file" up -d
+    else
+        docker_compose -f "$compose_file" up -d --build
+    fi
 
     if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
         # Clean up old images that are no longer used by any container


### PR DESCRIPTION
## Summary
- Parallel Docker builds overwhelm the server when cache is cold — 3 concurrent `npm ci` processes exhaust CPU/RAM, causing stalls and timeouts
- Build api, web, landing one at a time in prod/staging (dev keeps parallel)
- Bump timeouts to 25m command / 30m job for cold-cache headroom

## Context
PR #117 increased timeouts from 12m to 20m but both prod and staging still timed out — the server simply can't handle 3 parallel builds from scratch.

## Test plan
- [ ] Merge and verify the deploy completes successfully
- [ ] Subsequent deploys with warm cache should finish much faster