### PR TITLE
Build images before stopping containers to eliminate deploy downtime

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,30 +30,11 @@ jobs:
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
             DEPLOY_DIR=~/websites/timetrack-staging
 
-            OLD_DIR=~/websites/timetrack-monorepo
-
             # Clone on first deploy, otherwise just fetch
             if [ ! -d "$DEPLOY_DIR/.git" ]; then
               echo "=== First staging deploy: cloning repo ==="
               git clone "$REPO_URL" "$DEPLOY_DIR"
             fi
-
-            # TODO: Remove this migration block once both environments have deployed successfully
-            # Force-remove old containers by name. We can't rely on docker compose down
-            # because the compose file's project name changed from timetrack-monorepo
-            # to timetrack-staging, so 'down' won't find the old containers.
-            echo "=== Removing any leftover containers by name ==="
-            for name in timetrack-postgres-staging timetrack-api-staging timetrack-web-staging timetrack-redis-staging timetrack-landing-staging; do
-              docker rm -f "$name" 2>/dev/null || true
-            done
-
-            # Migrate env files from the old shared directory if missing
-            for f in docker.env docker.staging.env; do
-              if [ -f "$OLD_DIR/$f" ] && [ ! -f "$DEPLOY_DIR/$f" ]; then
-                cp "$OLD_DIR/$f" "$DEPLOY_DIR/$f"
-                echo "Copied $f from old directory"
-              fi
-            done
 
             cd "$DEPLOY_DIR"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,30 +27,11 @@ jobs:
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
             DEPLOY_DIR=~/websites/timetrack-production
 
-            OLD_DIR=~/websites/timetrack-monorepo
-
             # Clone on first deploy, otherwise just fetch
             if [ ! -d "$DEPLOY_DIR/.git" ]; then
               echo "=== First deploy: cloning repo ==="
               git clone "$REPO_URL" "$DEPLOY_DIR"
             fi
-
-            # TODO: Remove this migration block once both environments have deployed successfully
-            # Force-remove old containers by name. We can't rely on docker compose down
-            # because the compose file's project name changed from timetrack-monorepo
-            # to timetrack-production, so 'down' won't find the old containers.
-            echo "=== Removing any leftover containers by name ==="
-            for name in timetrack-postgres-prod timetrack-api-prod timetrack-web-prod timetrack-redis-prod timetrack-landing-prod; do
-              docker rm -f "$name" 2>/dev/null || true
-            done
-
-            # Migrate env files from the old shared directory if missing
-            for f in docker.env docker.staging.env; do
-              if [ -f "$OLD_DIR/$f" ] && [ ! -f "$DEPLOY_DIR/$f" ]; then
-                cp "$OLD_DIR/$f" "$DEPLOY_DIR/$f"
-                echo "Copied $f from old directory"
-              fi
-            done
 
             cd "$DEPLOY_DIR"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -167,52 +167,30 @@ deploy() {
     source "$env_file"
     set +a
 
-    # Stop existing containers
-    docker_compose -f "$compose_file" down --remove-orphans
-
-    # Force-remove any lingering containers by name.
-    # docker compose down only removes containers matching the current project
-    # name, so if the project name changed (e.g. directory rename or adding a
-    # name: field), old containers survive and block the next 'up'.
-    if [ "$mode" = "prod" ]; then
-        log_info "Removing any leftover production containers..."
-        for name in timetrack-postgres-prod timetrack-api-prod timetrack-web-prod timetrack-redis-prod timetrack-landing-prod; do
-            docker rm -f "$name" 2>/dev/null || true
-        done
-    elif [ "$mode" = "staging" ]; then
-        log_info "Removing any leftover staging containers..."
-        for name in timetrack-postgres-staging timetrack-api-staging timetrack-web-staging timetrack-redis-staging timetrack-landing-staging; do
-            docker rm -f "$name" 2>/dev/null || true
-        done
-    fi
-
     if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
-        # Remove dangling images left by previous builds
-        log_info "Pruning dangling Docker images..."
-        docker image prune -f
-
         # Remove old build cache (keeps recent layers for faster rebuilds)
         log_info "Pruning Docker build cache older than 7 days..."
         docker builder prune -f --filter "until=168h"
-    fi
 
-    # Build and start services
-    # In prod/staging, build sequentially to avoid overwhelming the server
-    # when Docker cache is cold (parallel npm ci can exhaust CPU/RAM).
-    if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
-        log_info "Building services sequentially..."
+        # Build new images while old containers keep serving traffic.
+        # Sequential builds avoid overwhelming the server when cache is cold.
+        log_info "Building new images (old containers still serving traffic)..."
         docker_compose -f "$compose_file" build api
         docker_compose -f "$compose_file" build web
         docker_compose -f "$compose_file" build landing
-        docker_compose -f "$compose_file" up -d
-    else
-        docker_compose -f "$compose_file" up -d --build
-    fi
 
-    if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
+        # Recreate only containers whose image/config changed.
+        # Postgres and redis are untouched (stock images, no rebuild needed).
+        log_info "Replacing containers with new images..."
+        docker_compose -f "$compose_file" up -d --remove-orphans
+
         # Clean up old images that are no longer used by any container
         log_info "Removing unused images from previous deployments..."
         docker image prune -af --filter "until=24h"
+    else
+        # Dev: full restart is fine
+        docker_compose -f "$compose_file" down --remove-orphans
+        docker_compose -f "$compose_file" up -d --build
     fi
 
     log_info "$mode deployment complete!"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,7 +41,7 @@ services:
       DATABASE_URL: postgresql://timetrack_user:${POSTGRES_PASSWORD}@postgres:5432/timetrack_db
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRES_IN: 7d
-      PORT: ${API_PORT:-3011}
+      PORT: 3011
       RATE_LIMIT_WINDOW_MS: 900000
       RATE_LIMIT_MAX_REQUESTS: 100
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
@@ -55,13 +55,13 @@ services:
     volumes:
       - api_logs:/app/logs
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${API_PORT:-3011}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3011/health"]
       interval: 30s
       timeout: 10s
       retries: 3
     # Uncomment to expose API port directly (optional for production - usually use reverse proxy)
     ports:
-      - "${API_PORT:-3011}:${API_PORT:-3011}"
+      - "${API_PORT:-3011}:3011"
 
   # Web UI Service (includes nginx for serving React app and proxying API)
   web:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -39,7 +39,7 @@ services:
       DATABASE_URL: postgresql://timetrack_user:${POSTGRES_PASSWORD}@postgres:5432/timetrack_db
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRES_IN: 7d
-      PORT: ${API_PORT:-3021}
+      PORT: 3011
       RATE_LIMIT_WINDOW_MS: 900000
       RATE_LIMIT_MAX_REQUESTS: 100
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
@@ -53,12 +53,12 @@ services:
     volumes:
       - staging_api_logs:/app/logs
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${API_PORT:-3021}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3011/health"]
       interval: 30s
       timeout: 10s
       retries: 3
     ports:
-      - "${API_PORT:-3021}:${API_PORT:-3021}"
+      - "${API_PORT:-3021}:3011"
 
   # Web UI Service (includes nginx for serving React app and proxying API)
   web:


### PR DESCRIPTION
## Summary

- **Root cause**: `deploy.sh` ran `docker compose down` before building images, taking the app offline for the entire 5-15 min build duration (502 Bad Gateway)
- **Fix**: Build new Docker images while old containers keep serving traffic, then `docker compose up -d` recreates only containers whose image changed (api, web, landing). Postgres and redis are untouched since they use stock images.
- **Cleanup**: Removed one-time migration blocks (force-remove containers, env file copy from old directory) that were added during the monorepo → separate directories migration and are no longer needed

## Before vs After

| | Before | After |
|---|---|---|
| Downtime | Entire build (5-15 min) | Only app container restart (~5-10s) |
| Database | Stopped during build | Never touched |
| Sequence | `down` → build → `up` | build → `up -d` (replaces changed containers) |

## Test plan

- [ ] Deploy to staging via `deploy-staging` label and verify no 502 during build phase
- [ ] Verify health checks pass after deploy
- [ ] Verify postgres/redis containers are NOT restarted (check uptime with `docker ps`)