### PR TITLE
Fix special characters in project names displayed as HTML entities

### DIFF
--- a/packages/api/src/middleware/sanitization.ts
+++ b/packages/api/src/middleware/sanitization.ts
@@ -21,6 +21,17 @@ const sanitizationConfig = {
 };
 
 /**
+ * Decode HTML entities back to plain text.
+ * DOMPurify encodes special chars (& → &amp;, etc.) because it outputs HTML,
+ * but we store plain text — so we need to reverse the encoding.
+ */
+const decodeHtmlEntities = (text: string): string => {
+  const el = window.document.createElement("div");
+  el.innerHTML = text;
+  return el.textContent || "";
+};
+
+/**
  * Sanitizes a string input to remove potential XSS vectors
  */
 export const sanitizeString = (input: string): string => {
@@ -30,6 +41,10 @@ export const sanitizeString = (input: string): string => {
 
   // First pass: Remove HTML tags and attributes
   let sanitized = purify.sanitize(input, sanitizationConfig);
+
+  // Decode HTML entities introduced by DOMPurify (e.g. &amp; → &)
+  // We store plain text, not HTML, so entities must not be persisted
+  sanitized = decodeHtmlEntities(sanitized);
 
   // Additional cleaning for common XSS patterns
   sanitized = sanitized


### PR DESCRIPTION
## Summary

- Project names with special characters (e.g. `&`, `<`, `>`) were stored in the database with HTML entity encoding (`React&Win` → `React&amp;Win`) because DOMPurify's `sanitize()` outputs HTML
- The UI then displayed the literal encoded text (`React&amp;Win`) instead of the intended name
- Added a `decodeHtmlEntities()` step after DOMPurify sanitization in the API's input sanitization middleware, so plain text is stored in the DB
- XSS protection is fully preserved: DOMPurify still strips HTML tags, dangerous patterns are still cleaned, and angle brackets are still removed

## Test plan

- [ ] Create a project with `&` in the name (e.g. "React&Win") — verify it displays correctly everywhere (project list, timer dropdown, task views, reports)
- [ ] Create a project with other special chars (e.g. `"`, `'`, `<`, `>`) — verify names are stored and displayed as plain text
- [ ] Verify XSS payloads like `<script>alert(1)</script>` are still stripped
- [ ] Check existing projects with encoded names — note: already-stored encoded names will need manual DB correction or re-save