### PR TITLE
Fix logout caused by socket reconnect loop exhausting rate limit

### DIFF
--- a/packages/ui/src/services/socket.ts
+++ b/packages/ui/src/services/socket.ts
@@ -75,7 +75,17 @@ class SocketService {
       return;
     }
 
-    this.disconnect();
+    // Clean up existing socket without resetting reconnect counter
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      this.socket.removeAllListeners();
+      this.socket.disconnect();
+      this.socket = null;
+    }
+
     this.setConnectionState("connecting");
 
     this.socket = io(SOCKET_URL, {

--- a/packages/ui/src/store/slices/authSlice.ts
+++ b/packages/ui/src/store/slices/authSlice.ts
@@ -115,12 +115,13 @@ export const getCurrentUser = createAsyncThunk(
       saveUserToStorage(response);
       return response;
     } catch (error: any) {
+      const status = error.response?.status;
       const errorMessage =
         error.response?.data?.error ||
         error.response?.data?.message ||
         error.message ||
         "Failed to get user";
-      return rejectWithValue(errorMessage);
+      return rejectWithValue({ message: errorMessage, status });
     }
   }
 );
@@ -229,12 +230,20 @@ const authSlice = createSlice({
       })
       .addCase(getCurrentUser.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
-        state.isAuthenticated = false;
-        state.token = null;
+        const payload = action.payload as { message: string; status?: number } | string;
+        const status = typeof payload === 'object' ? payload.status : undefined;
+        const message = typeof payload === 'object' ? payload.message : payload;
+        state.error = message;
         state.hasCheckedAuth = true;
-        localStorage.removeItem("token");
-        removeUserFromStorage();
+
+        // Only clear auth on 401 (invalid/expired token).
+        // Other errors (429 rate limit, 503, network errors) should not log the user out.
+        if (status === 401) {
+          state.isAuthenticated = false;
+          state.token = null;
+          localStorage.removeItem("token");
+          removeUserFromStorage();
+        }
       })
       // Update profile
       .addCase(updateProfile.pending, (state) => {


### PR DESCRIPTION
## Summary

- Socket reconnect counter never incremented because `connect()` called `disconnect()` which reset `reconnectAttempts` to 0 every time. The loop ran forever at "attempt 1/10", burning ~1 request/second against the rate limit (100 req/15min). Once the rate limit was exhausted, any page refresh would 429 on `/auth/me`, triggering `getCurrentUser.rejected` which cleared the auth token — logging the user out.
- `getCurrentUser.rejected` now only clears auth on 401 (invalid/expired token). Rate limits (429), server errors (503), and network errors no longer log the user out.

## Root cause

The rate limit headers confirmed the issue: `RateLimit-Remaining: 6` out of 100, all consumed by the socket reconnect loop.

Closes #123