### PR TITLE
Add personal API keys for programmatic access

### DIFF
--- a/packages/api/prisma/migrations/20260508000000_secure_api_keys/migration.sql
+++ b/packages/api/prisma/migrations/20260508000000_secure_api_keys/migration.sql
@@ -1,3 +1,13 @@
+-- Safety guard: this migration is only safe if api_keys is empty. Prior to
+-- this PR no code ever inserted rows, but if any environment somehow has
+-- data, fail loudly rather than producing a confusing mid-ALTER null violation.
+DO $$
+BEGIN
+  IF (SELECT COUNT(*) FROM api_keys) > 0 THEN
+    RAISE EXCEPTION 'api_keys is non-empty; manual reconciliation required before this migration can run';
+  END IF;
+END $$;
+
 -- DropIndex
 DROP INDEX "api_keys_key_idx";
 

--- a/packages/api/prisma/migrations/20260508000000_secure_api_keys/migration.sql
+++ b/packages/api/prisma/migrations/20260508000000_secure_api_keys/migration.sql
@@ -1,0 +1,18 @@
+-- DropIndex
+DROP INDEX "api_keys_key_idx";
+
+-- DropIndex
+DROP INDEX "api_keys_key_key";
+
+-- AlterTable
+ALTER TABLE "api_keys" DROP COLUMN "key",
+DROP COLUMN "lastUsed",
+ADD COLUMN     "key_hash" TEXT NOT NULL,
+ADD COLUMN     "key_prefix" TEXT NOT NULL,
+ADD COLUMN     "last_used_at" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "api_keys_key_hash_key" ON "api_keys"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "api_keys_key_hash_idx" ON "api_keys"("key_hash");

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -107,13 +107,14 @@ model TimeEntry {
 }
 
 model ApiKey {
-  id        String    @id @default(cuid())
-  name      String
-  key       String    @unique
-  isActive  Boolean   @default(true)
-  lastUsed  DateTime?
-  createdAt DateTime  @default(now())
-  expiresAt DateTime?
+  id         String    @id @default(cuid())
+  name       String
+  keyHash    String    @unique @map("key_hash")
+  keyPrefix  String    @map("key_prefix")
+  isActive   Boolean   @default(true)
+  lastUsedAt DateTime? @map("last_used_at")
+  createdAt  DateTime  @default(now())
+  expiresAt  DateTime?
 
   // Relations
   userId String
@@ -121,7 +122,7 @@ model ApiKey {
 
   @@map("api_keys")
   @@index([userId])
-  @@index([key])
+  @@index([keyHash])
   @@index([userId, isActive])
 }
 

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -2,6 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import { prisma } from "../utils/database";
 import { createError } from "./errorHandler";
+import { hashApiKey, isApiKeyToken } from "../utils/apiKeys";
+
+export type AuthMethod = "jwt" | "api_key";
 
 export interface AuthenticatedRequest extends Request {
   user?: {
@@ -9,7 +12,58 @@ export interface AuthenticatedRequest extends Request {
     email: string;
     name: string;
   };
+  authMethod?: AuthMethod;
+  apiKeyId?: string;
 }
+
+const authenticateApiKey = async (token: string) => {
+  const hash = hashApiKey(token);
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { keyHash: hash },
+    include: {
+      user: {
+        select: { id: true, email: true, name: true },
+      },
+    },
+  });
+
+  if (!apiKey || !apiKey.isActive) {
+    throw createError("Invalid API key", 401);
+  }
+
+  if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+    throw createError("API key expired", 401);
+  }
+
+  // Bump lastUsedAt asynchronously; we don't need to wait.
+  prisma.apiKey
+    .update({ where: { id: apiKey.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {});
+
+  return { user: apiKey.user, apiKeyId: apiKey.id };
+};
+
+const authenticateJwt = async (token: string) => {
+  if (!process.env.JWT_SECRET) {
+    throw createError("JWT secret not configured", 500);
+  }
+
+  const decoded = jwt.verify(token, process.env.JWT_SECRET) as {
+    userId: string;
+    email: string;
+  };
+
+  const user = await prisma.user.findUnique({
+    where: { id: decoded.userId },
+    select: { id: true, email: true, name: true },
+  });
+
+  if (!user) {
+    throw createError("User not found", 401);
+  }
+
+  return { user };
+};
 
 export const authenticate = async (
   req: AuthenticatedRequest,
@@ -25,29 +79,17 @@ export const authenticate = async (
 
     const token = authHeader.substring(7);
 
-    if (!process.env.JWT_SECRET) {
-      throw createError("JWT secret not configured", 500);
+    if (isApiKeyToken(token)) {
+      const { user, apiKeyId } = await authenticateApiKey(token);
+      req.user = user;
+      req.authMethod = "api_key";
+      req.apiKeyId = apiKeyId;
+    } else {
+      const { user } = await authenticateJwt(token);
+      req.user = user;
+      req.authMethod = "jwt";
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET) as {
-      userId: string;
-      email: string;
-    };
-
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-      },
-    });
-
-    if (!user) {
-      throw createError("User not found", 401);
-    }
-
-    req.user = user;
     next();
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
@@ -60,6 +102,17 @@ export const authenticate = async (
   }
 };
 
+export const requireJwt = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  if (req.authMethod !== "jwt") {
+    return next(createError("This action requires an interactive session", 403));
+  }
+  next();
+};
+
 export const optionalAuth = async (
   req: AuthenticatedRequest,
   res: Response,
@@ -67,38 +120,26 @@ export const optionalAuth = async (
 ) => {
   try {
     const authHeader = req.headers.authorization;
-
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return next();
     }
 
     const token = authHeader.substring(7);
 
-    if (!process.env.JWT_SECRET) {
-      return next();
-    }
-
-    const decoded = jwt.verify(token, process.env.JWT_SECRET) as {
-      userId: string;
-      email: string;
-    };
-
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.userId },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-      },
-    });
-
-    if (user) {
+    if (isApiKeyToken(token)) {
+      const { user, apiKeyId } = await authenticateApiKey(token);
       req.user = user;
+      req.authMethod = "api_key";
+      req.apiKeyId = apiKeyId;
+    } else if (process.env.JWT_SECRET) {
+      const { user } = await authenticateJwt(token);
+      req.user = user;
+      req.authMethod = "jwt";
     }
 
     next();
   } catch (error) {
-    // Ignore auth errors for optional auth
+    // Optional auth swallows errors so unauthenticated traffic still flows.
     next();
   }
 };

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken";
 import { prisma } from "../utils/database";
 import { createError } from "./errorHandler";
 import { hashApiKey, isApiKeyToken } from "../utils/apiKeys";
+import { logger } from "../utils/logger";
 
 export type AuthMethod = "jwt" | "api_key";
 
@@ -13,8 +14,9 @@ export interface AuthenticatedRequest extends Request {
     name: string;
   };
   authMethod?: AuthMethod;
-  apiKeyId?: string;
 }
+
+const LAST_USED_DEBOUNCE_MS = 60_000;
 
 const authenticateApiKey = async (token: string) => {
   const hash = hashApiKey(token);
@@ -35,12 +37,22 @@ const authenticateApiKey = async (token: string) => {
     throw createError("API key expired", 401);
   }
 
-  // Bump lastUsedAt asynchronously; we don't need to wait.
-  prisma.apiKey
-    .update({ where: { id: apiKey.id }, data: { lastUsedAt: new Date() } })
-    .catch(() => {});
+  const now = new Date();
+  const stale =
+    !apiKey.lastUsedAt ||
+    now.getTime() - apiKey.lastUsedAt.getTime() > LAST_USED_DEBOUNCE_MS;
+  if (stale) {
+    prisma.apiKey
+      .update({ where: { id: apiKey.id }, data: { lastUsedAt: now } })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(
+          `Failed to update lastUsedAt for api_key ${apiKey.id}: ${message}`
+        );
+      });
+  }
 
-  return { user: apiKey.user, apiKeyId: apiKey.id };
+  return apiKey.user;
 };
 
 const authenticateJwt = async (token: string) => {
@@ -80,10 +92,8 @@ export const authenticate = async (
     const token = authHeader.substring(7);
 
     if (isApiKeyToken(token)) {
-      const { user, apiKeyId } = await authenticateApiKey(token);
-      req.user = user;
+      req.user = await authenticateApiKey(token);
       req.authMethod = "api_key";
-      req.apiKeyId = apiKeyId;
     } else {
       const { user } = await authenticateJwt(token);
       req.user = user;
@@ -120,26 +130,38 @@ export const optionalAuth = async (
 ) => {
   try {
     const authHeader = req.headers.authorization;
+
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return next();
     }
 
     const token = authHeader.substring(7);
 
-    if (isApiKeyToken(token)) {
-      const { user, apiKeyId } = await authenticateApiKey(token);
+    if (!process.env.JWT_SECRET) {
+      return next();
+    }
+
+    const decoded = jwt.verify(token, process.env.JWT_SECRET) as {
+      userId: string;
+      email: string;
+    };
+
+    const user = await prisma.user.findUnique({
+      where: { id: decoded.userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+      },
+    });
+
+    if (user) {
       req.user = user;
-      req.authMethod = "api_key";
-      req.apiKeyId = apiKeyId;
-    } else if (process.env.JWT_SECRET) {
-      const { user } = await authenticateJwt(token);
-      req.user = user;
-      req.authMethod = "jwt";
     }
 
     next();
   } catch (error) {
-    // Optional auth swallows errors so unauthenticated traffic still flows.
+    // Ignore auth errors for optional auth
     next();
   }
 };

--- a/packages/api/src/routes/apiKeys.ts
+++ b/packages/api/src/routes/apiKeys.ts
@@ -22,6 +22,9 @@ const createSchema = z.object({
   expiresAt: z
     .string()
     .datetime({ message: "expiresAt must be ISO 8601" })
+    .refine((v) => new Date(v) > new Date(), {
+      message: "expiresAt must be in the future",
+    })
     .optional(),
 });
 
@@ -91,34 +94,31 @@ router.post(
   "/",
   asyncHandler(async (req: AuthenticatedRequest, res) => {
     const { name, expiresAt } = createSchema.parse(req.body);
-
-    if (expiresAt && new Date(expiresAt) <= new Date()) {
-      throw createError("expiresAt must be in the future", 400);
-    }
-
-    const activeCount = await prisma.apiKey.count({
-      where: { userId: req.user!.id, isActive: true },
-    });
-    if (activeCount >= MAX_KEYS_PER_USER) {
-      throw createError(
-        `You can have at most ${MAX_KEYS_PER_USER} active API keys`,
-        400
-      );
-    }
-
     const { token, hash, prefix } = generateApiKey();
 
-    const apiKey = await prisma.apiKey.create({
-      data: {
-        userId: req.user!.id,
-        name: name.trim(),
-        keyHash: hash,
-        keyPrefix: prefix,
-        expiresAt: expiresAt ? new Date(expiresAt) : null,
-      },
-      select: apiKeySelect,
+    const apiKey = await prisma.$transaction(async (tx: typeof prisma) => {
+      const activeCount = await tx.apiKey.count({
+        where: { userId: req.user!.id, isActive: true },
+      });
+      if (activeCount >= MAX_KEYS_PER_USER) {
+        throw createError(
+          `You can have at most ${MAX_KEYS_PER_USER} active API keys`,
+          400
+        );
+      }
+      return tx.apiKey.create({
+        data: {
+          userId: req.user!.id,
+          name: name.trim(),
+          keyHash: hash,
+          keyPrefix: prefix,
+          expiresAt: expiresAt ? new Date(expiresAt) : null,
+        },
+        select: apiKeySelect,
+      });
     });
 
+    res.set("Cache-Control", "no-store");
     res.status(201).json({
       message: "API key created. Store the token securely — it will not be shown again.",
       apiKey,

--- a/packages/api/src/routes/apiKeys.ts
+++ b/packages/api/src/routes/apiKeys.ts
@@ -1,0 +1,168 @@
+import express from "express";
+import { z } from "zod";
+import { prisma } from "../utils/database";
+import { asyncHandler, createError } from "../middleware/errorHandler";
+import {
+  authenticate,
+  requireJwt,
+  AuthenticatedRequest,
+} from "../middleware/auth";
+import { generateApiKey } from "../utils/apiKeys";
+
+const router = express.Router();
+
+const MAX_KEYS_PER_USER = 10;
+
+router.use(authenticate);
+// Managing keys requires an interactive session — keys cannot manage themselves.
+router.use(requireJwt);
+
+const createSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name too long"),
+  expiresAt: z
+    .string()
+    .datetime({ message: "expiresAt must be ISO 8601" })
+    .optional(),
+});
+
+const apiKeySelect = {
+  id: true,
+  name: true,
+  keyPrefix: true,
+  isActive: true,
+  lastUsedAt: true,
+  createdAt: true,
+  expiresAt: true,
+} as const;
+
+/**
+ * @swagger
+ * /api-keys:
+ *   get:
+ *     summary: List the current user's API keys
+ *     tags: [ApiKeys]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: API keys retrieved
+ */
+router.get(
+  "/",
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const apiKeys = await prisma.apiKey.findMany({
+      where: { userId: req.user!.id },
+      select: apiKeySelect,
+      orderBy: { createdAt: "desc" },
+    });
+    res.json({ apiKeys });
+  })
+);
+
+/**
+ * @swagger
+ * /api-keys:
+ *   post:
+ *     summary: Create a new API key. The plaintext token is returned ONCE.
+ *     tags: [ApiKeys]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 maxLength: 100
+ *               expiresAt:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       201:
+ *         description: API key created — token returned once
+ *       400:
+ *         description: Validation error or limit reached
+ */
+router.post(
+  "/",
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const { name, expiresAt } = createSchema.parse(req.body);
+
+    if (expiresAt && new Date(expiresAt) <= new Date()) {
+      throw createError("expiresAt must be in the future", 400);
+    }
+
+    const activeCount = await prisma.apiKey.count({
+      where: { userId: req.user!.id, isActive: true },
+    });
+    if (activeCount >= MAX_KEYS_PER_USER) {
+      throw createError(
+        `You can have at most ${MAX_KEYS_PER_USER} active API keys`,
+        400
+      );
+    }
+
+    const { token, hash, prefix } = generateApiKey();
+
+    const apiKey = await prisma.apiKey.create({
+      data: {
+        userId: req.user!.id,
+        name: name.trim(),
+        keyHash: hash,
+        keyPrefix: prefix,
+        expiresAt: expiresAt ? new Date(expiresAt) : null,
+      },
+      select: apiKeySelect,
+    });
+
+    res.status(201).json({
+      message: "API key created. Store the token securely — it will not be shown again.",
+      apiKey,
+      token,
+    });
+  })
+);
+
+/**
+ * @swagger
+ * /api-keys/{id}:
+ *   delete:
+ *     summary: Revoke an API key
+ *     tags: [ApiKeys]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: API key revoked
+ *       404:
+ *         description: API key not found
+ */
+router.delete(
+  "/:id",
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const { id } = req.params;
+
+    const existing = await prisma.apiKey.findFirst({
+      where: { id, userId: req.user!.id },
+    });
+    if (!existing) {
+      throw createError("API key not found", 404);
+    }
+
+    await prisma.apiKey.delete({ where: { id } });
+
+    res.json({ message: "API key revoked" });
+  })
+);
+
+export default router;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -7,7 +7,7 @@ import svgCaptcha from "svg-captcha";
 import crypto from "crypto";
 import { prisma } from "../utils/database";
 import { asyncHandler, createError } from "../middleware/errorHandler";
-import { authenticate, AuthenticatedRequest } from "../middleware/auth";
+import { authenticate, requireJwt, AuthenticatedRequest } from "../middleware/auth";
 import { emailService } from "../utils/email";
 
 const router = express.Router();
@@ -452,6 +452,7 @@ router.get(
 router.post(
   "/refresh",
   authenticate,
+  requireJwt,
   asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     // Generate new JWT token
     const jwtSecret = process.env.JWT_SECRET;

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -3,7 +3,7 @@ import bcrypt from "bcryptjs";
 import { z } from "zod";
 import { prisma } from "../utils/database";
 import { asyncHandler, createError } from "../middleware/errorHandler";
-import { authenticate, AuthenticatedRequest } from "../middleware/auth";
+import { authenticate, requireJwt, AuthenticatedRequest } from "../middleware/auth";
 
 const router = express.Router();
 
@@ -117,6 +117,7 @@ const changePasswordSchema = z.object({
  */
 router.put(
   "/profile",
+  requireJwt,
   asyncHandler(async (req: AuthenticatedRequest, res) => {
     const updateData = updateProfileSchema.parse(req.body);
 
@@ -183,6 +184,7 @@ router.put(
  */
 router.post(
   "/change-password",
+  requireJwt,
   asyncHandler(async (req: AuthenticatedRequest, res) => {
     const { currentPassword, newPassword } = changePasswordSchema.parse(
       req.body

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -22,6 +22,7 @@ import taskRoutes from "./routes/tasks";
 import timeEntryRoutes from "./routes/timeEntries";
 import reportRoutes from "./routes/reports";
 import favoriteRoutes from "./routes/favorites";
+import apiKeyRoutes from "./routes/apiKeys";
 
 // Load environment variables
 dotenv.config();
@@ -415,6 +416,7 @@ app.use("/tasks", taskRoutes);
 app.use("/time-entries", timeEntryRoutes);
 app.use("/reports", reportRoutes);
 app.use("/favorites", favoriteRoutes);
+app.use("/api-keys", apiKeyRoutes);
 
 // Socket.IO authentication middleware
 io.use(async (socket, next) => {

--- a/packages/api/src/utils/apiKeys.ts
+++ b/packages/api/src/utils/apiKeys.ts
@@ -1,0 +1,27 @@
+import crypto from "crypto";
+
+export const API_KEY_PREFIX = "tt_";
+const RANDOM_BYTES = 24; // 48 hex chars after the prefix
+const STORED_PREFIX_LENGTH = API_KEY_PREFIX.length + 8;
+
+export interface GeneratedApiKey {
+  token: string;
+  hash: string;
+  prefix: string;
+}
+
+export const generateApiKey = (): GeneratedApiKey => {
+  const random = crypto.randomBytes(RANDOM_BYTES).toString("hex");
+  const token = `${API_KEY_PREFIX}${random}`;
+  return {
+    token,
+    hash: hashApiKey(token),
+    prefix: token.slice(0, STORED_PREFIX_LENGTH),
+  };
+};
+
+export const hashApiKey = (token: string): string =>
+  crypto.createHash("sha256").update(token).digest("hex");
+
+export const isApiKeyToken = (token: string): boolean =>
+  token.startsWith(API_KEY_PREFIX);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -87,25 +87,3 @@ export interface ApiError {
   statusCode?: number;
 }
 
-// API Key types (programmatic access tokens)
-export interface ApiKey {
-  id: string;
-  name: string;
-  keyPrefix: string;
-  isActive: boolean;
-  lastUsedAt?: string | null;
-  createdAt: string;
-  expiresAt?: string | null;
-}
-
-export interface CreateApiKeyRequest {
-  name: string;
-  expiresAt?: string;
-}
-
-export interface CreateApiKeyResponse {
-  message: string;
-  apiKey: ApiKey;
-  // Plaintext token — returned ONCE on creation, never again.
-  token: string;
-}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -86,3 +86,26 @@ export interface ApiError {
   code?: string;
   statusCode?: number;
 }
+
+// API Key types (programmatic access tokens)
+export interface ApiKey {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  isActive: boolean;
+  lastUsedAt?: string | null;
+  createdAt: string;
+  expiresAt?: string | null;
+}
+
+export interface CreateApiKeyRequest {
+  name: string;
+  expiresAt?: string;
+}
+
+export interface CreateApiKeyResponse {
+  message: string;
+  apiKey: ApiKey;
+  // Plaintext token — returned ONCE on creation, never again.
+  token: string;
+}

--- a/packages/ui/src/components/ApiKeysSection.tsx
+++ b/packages/ui/src/components/ApiKeysSection.tsx
@@ -1,0 +1,259 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  ClipboardDocumentIcon,
+  PlusIcon,
+  TrashIcon,
+  ExclamationTriangleIcon,
+} from "@heroicons/react/24/outline";
+import { toast } from "react-hot-toast";
+import { AppDispatch, RootState } from "../store";
+import {
+  fetchApiKeys,
+  createApiKey,
+  revokeApiKey,
+} from "../store/slices/apiKeysSlice";
+
+const formatDate = (value?: string | null) => {
+  if (!value) return null;
+  const d = new Date(value);
+  return d.toLocaleString();
+};
+
+const ApiKeysSection: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { apiKeys, loading } = useSelector(
+    (state: RootState) => state.apiKeys
+  );
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [name, setName] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [newToken, setNewToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    dispatch(fetchApiKeys());
+  }, [dispatch]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setSubmitting(true);
+    try {
+      const result = await dispatch(
+        createApiKey({
+          name: name.trim(),
+          expiresAt: expiresAt
+            ? new Date(expiresAt).toISOString()
+            : undefined,
+        })
+      ).unwrap();
+      setNewToken(result.token);
+      setShowCreateForm(false);
+      setName("");
+      setExpiresAt("");
+      toast.success("API key created");
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to create API key");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRevoke = async (id: string, keyName: string) => {
+    if (!window.confirm(`Revoke "${keyName}"? Any client using it will lose access immediately.`)) {
+      return;
+    }
+    try {
+      await dispatch(revokeApiKey(id)).unwrap();
+      toast.success("API key revoked");
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to revoke API key");
+    }
+  };
+
+  const copyToken = async () => {
+    if (!newToken) return;
+    try {
+      await navigator.clipboard.writeText(newToken);
+      toast.success("Token copied to clipboard");
+    } catch {
+      toast.error("Failed to copy — select and copy manually");
+    }
+  };
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h3 className="text-lg font-medium text-gray-900">API Keys</h3>
+          <p className="text-sm text-gray-500 mt-1">
+            Tokens for programmatic access (CLI tools, AI agents, integrations).
+            Time entries created with an API key are flagged for billing.
+          </p>
+        </div>
+        {!showCreateForm && !newToken && (
+          <button
+            type="button"
+            onClick={() => setShowCreateForm(true)}
+            className="btn-primary flex items-center gap-1 whitespace-nowrap"
+          >
+            <PlusIcon className="h-4 w-4" />
+            New Key
+          </button>
+        )}
+      </div>
+
+      {newToken && (
+        <div className="mb-6 p-4 border border-amber-300 bg-amber-50 rounded-md">
+          <div className="flex gap-2 mb-2">
+            <ExclamationTriangleIcon className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-900 font-medium">
+              Copy your token now. It will not be shown again.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 mt-2">
+            <code className="flex-1 px-3 py-2 bg-white border border-amber-300 rounded text-sm font-mono break-all">
+              {newToken}
+            </code>
+            <button
+              type="button"
+              onClick={copyToken}
+              className="btn-secondary flex items-center gap-1 whitespace-nowrap"
+              title="Copy to clipboard"
+            >
+              <ClipboardDocumentIcon className="h-4 w-4" />
+              Copy
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setNewToken(null)}
+            className="mt-3 text-sm text-amber-900 underline hover:no-underline"
+          >
+            I've saved it — dismiss
+          </button>
+        </div>
+      )}
+
+      {showCreateForm && (
+        <form onSubmit={handleCreate} className="mb-6 space-y-3 p-4 bg-gray-50 rounded-md">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="input-field mt-1"
+              placeholder="e.g. Claude Code, my-laptop"
+              maxLength={100}
+              required
+              autoFocus
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Expires (optional)
+            </label>
+            <input
+              type="date"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="input-field mt-1"
+              min={new Date(Date.now() + 86400000).toISOString().slice(0, 10)}
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              Leave blank for a key that never expires.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={submitting || !name.trim()}
+              className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Creating..." : "Create Key"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowCreateForm(false);
+                setName("");
+                setExpiresAt("");
+              }}
+              className="btn-secondary"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading && apiKeys.length === 0 ? (
+        <p className="text-sm text-gray-500">Loading...</p>
+      ) : apiKeys.length === 0 ? (
+        <p className="text-sm text-gray-500 italic">
+          No API keys yet. Create one to give a tool programmatic access.
+        </p>
+      ) : (
+        <div className="divide-y divide-gray-200">
+          {apiKeys.map((key) => {
+            const expired =
+              key.expiresAt && new Date(key.expiresAt) < new Date();
+            return (
+              <div
+                key={key.id}
+                className="py-3 flex items-start justify-between gap-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-medium text-gray-900 truncate">
+                      {key.name}
+                    </span>
+                    <code className="text-xs text-gray-600 bg-gray-100 px-2 py-0.5 rounded font-mono">
+                      {key.keyPrefix}…
+                    </code>
+                    {expired && (
+                      <span className="text-xs px-2 py-0.5 bg-red-100 text-red-700 rounded">
+                        expired
+                      </span>
+                    )}
+                    {!key.isActive && !expired && (
+                      <span className="text-xs px-2 py-0.5 bg-gray-200 text-gray-700 rounded">
+                        inactive
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500 space-x-3">
+                    <span>Created {formatDate(key.createdAt)}</span>
+                    <span>
+                      Last used{" "}
+                      {key.lastUsedAt ? formatDate(key.lastUsedAt) : "never"}
+                    </span>
+                    {key.expiresAt && (
+                      <span>Expires {formatDate(key.expiresAt)}</span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(key.id, key.name)}
+                  className="text-red-600 hover:text-red-800 p-2"
+                  title="Revoke"
+                >
+                  <TrashIcon className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApiKeysSection;

--- a/packages/ui/src/components/ApiKeysSection.tsx
+++ b/packages/ui/src/components/ApiKeysSection.tsx
@@ -55,8 +55,9 @@ const ApiKeysSection: React.FC = () => {
       setName("");
       setExpiresAt("");
       toast.success("API key created");
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to create API key");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to create API key";
+      toast.error(message);
     } finally {
       setSubmitting(false);
     }
@@ -69,8 +70,9 @@ const ApiKeysSection: React.FC = () => {
     try {
       await dispatch(revokeApiKey(id)).unwrap();
       toast.success("API key revoked");
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to revoke API key");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to revoke API key";
+      toast.error(message);
     }
   };
 
@@ -244,6 +246,7 @@ const ApiKeysSection: React.FC = () => {
                   onClick={() => handleRevoke(key.id, key.name)}
                   className="text-red-600 hover:text-red-800 p-2"
                   title="Revoke"
+                  aria-label={`Revoke API key ${key.name}`}
                 >
                   <TrashIcon className="h-4 w-4" />
                 </button>

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { RootState, AppDispatch } from "../store";
 import { updateProfile } from "../store/slices/authSlice";
 import { toast } from "react-hot-toast";
+import ApiKeysSection from "../components/ApiKeysSection";
 
 const Settings: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -322,6 +323,8 @@ const Settings: React.FC = () => {
           </div>
         </div>
       </div>
+
+      <ApiKeysSection />
     </div>
   );
 };

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -3,6 +3,7 @@ import { User } from "../store/slices/authSlice";
 import { Project, Task } from "../store/slices/projectsSlice";
 import { TimeEntry } from "../store/slices/timeEntriesSlice";
 import { Favorite } from "../store/slices/favoritesSlice";
+import { ApiKey } from "../store/slices/apiKeysSlice";
 
 // In production the UI is served by nginx which reverse-proxies /api/ to the
 // API container, so no absolute URL is needed. VITE_API_URL is only required
@@ -488,6 +489,29 @@ class APIClient {
 
   };
 
+  // API Keys (programmatic access tokens)
+  apiKeys = {
+    list: async () => {
+      const response = await this.request<{ apiKeys: ApiKey[] }>(
+        "GET",
+        "/api-keys"
+      );
+      return response.apiKeys;
+    },
+
+    create: async (data: { name: string; expiresAt?: string }) => {
+      return this.request<{
+        message: string;
+        apiKey: ApiKey;
+        token: string;
+      }>("POST", "/api-keys", data);
+    },
+
+    revoke: async (id: string) => {
+      return this.request<{ message: string }>("DELETE", `/api-keys/${id}`);
+    },
+  };
+
   // Health check
   health = {
     check: async () => {
@@ -513,6 +537,7 @@ export const tasksAPI = apiClient.tasks;
 export const timeEntriesAPI = apiClient.timeEntries;
 export const reportsAPI = apiClient.reports;
 export const favoritesAPI = apiClient.favorites;
+export const apiKeysAPI = apiClient.apiKeys;
 export const healthAPI = apiClient.health;
 
 export default apiClient;

--- a/packages/ui/src/store/index.ts
+++ b/packages/ui/src/store/index.ts
@@ -6,6 +6,7 @@ import timeEntriesSlice from "./slices/timeEntriesSlice";
 import dashboardSlice from "./slices/dashboardSlice";
 import reportsSlice from "./slices/reportsSlice";
 import favoritesSlice from "./slices/favoritesSlice";
+import apiKeysSlice from "./slices/apiKeysSlice";
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ export const store = configureStore({
     dashboard: dashboardSlice,
     reports: reportsSlice,
     favorites: favoritesSlice,
+    apiKeys: apiKeysSlice,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/packages/ui/src/store/slices/apiKeysSlice.ts
+++ b/packages/ui/src/store/slices/apiKeysSlice.ts
@@ -1,0 +1,83 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { apiKeysAPI } from "../../services/api";
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  isActive: boolean;
+  lastUsedAt?: string | null;
+  createdAt: string;
+  expiresAt?: string | null;
+}
+
+interface ApiKeysState {
+  apiKeys: ApiKey[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: ApiKeysState = {
+  apiKeys: [],
+  loading: false,
+  error: null,
+};
+
+export const fetchApiKeys = createAsyncThunk("apiKeys/fetch", async () => {
+  return apiKeysAPI.list();
+});
+
+export const createApiKey = createAsyncThunk(
+  "apiKeys/create",
+  async (data: { name: string; expiresAt?: string }) => {
+    return apiKeysAPI.create(data);
+  }
+);
+
+export const revokeApiKey = createAsyncThunk(
+  "apiKeys/revoke",
+  async (id: string) => {
+    await apiKeysAPI.revoke(id);
+    return id;
+  }
+);
+
+const apiKeysSlice = createSlice({
+  name: "apiKeys",
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchApiKeys.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchApiKeys.fulfilled, (state, action) => {
+        state.loading = false;
+        state.apiKeys = action.payload;
+      })
+      .addCase(fetchApiKeys.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Failed to fetch API keys";
+      })
+      .addCase(createApiKey.fulfilled, (state, action) => {
+        state.apiKeys.unshift(action.payload.apiKey);
+      })
+      .addCase(createApiKey.rejected, (state, action) => {
+        state.error = action.error.message || "Failed to create API key";
+      })
+      .addCase(revokeApiKey.fulfilled, (state, action) => {
+        state.apiKeys = state.apiKeys.filter((k) => k.id !== action.payload);
+      })
+      .addCase(revokeApiKey.rejected, (state, action) => {
+        state.error = action.error.message || "Failed to revoke API key";
+      });
+  },
+});
+
+export const { clearError } = apiKeysSlice.actions;
+export default apiKeysSlice.reducer;


### PR DESCRIPTION
## Summary
- Wires up the previously stubbed `ApiKey` model so users can issue tokens for CLI tools, AI agents, and integrations
- Tokens are stored as a sha256 hash; the plaintext is shown to the user **once** at creation
- Foundation for the upcoming MCP server (PR C) and AI source-labeling work (PR B)

## What changed
- **Schema**: `ApiKey.key` (plaintext) → `keyHash` + `keyPrefix`; `lastUsed` → `lastUsedAt`. Destructive, but the table has zero rows since no code ever referenced it.
- **Auth middleware**: detects `Bearer tt_*` tokens, looks them up by hash, checks `isActive` + `expiresAt`, bumps `lastUsedAt` async, sets `req.authMethod = 'api_key' | 'jwt'`.
- **`requireJwt` guard**: blocks API-key holders from managing API keys (you can't bootstrap more access from your own access).
- **Routes** at `/api-keys`: list, create (returns plaintext once), revoke. Capped at 10 active keys per user.
- **UI**: new "API Keys" section on the Settings page — list, create-with-optional-expiry, copy-to-clipboard banner, revoke confirmation.

## Notes for reviewer
- **No automated tests in this PR.** The existing Jest config doesn't transform TypeScript (`src/routes/__tests__/timeEntries.test.ts` was already failing before this branch). Fixing the test runner is out of scope here; manual verification was done end-to-end.
- The MCP server (PR C) will use these tokens via a `TIMETRACK_API_KEY` env var.

## Test plan
- [ ] Run `npm run dev` to bring up the stack; the migration applies on container start
- [ ] Log in as `test@example.com / 123456`, navigate to Settings
- [ ] Verify the "API Keys" section is visible with the empty state
- [ ] Click "+ New Key", create a key named e.g. "Claude Code"; verify the plaintext token banner appears with a Copy button
- [ ] Dismiss the banner; verify the key appears in the list with prefix, "Last used never", and a created timestamp
- [ ] In a terminal: `curl http://localhost:3011/projects -H "Authorization: Bearer tt_..."` — should return projects
- [ ] `curl http://localhost:3011/api-keys -H "Authorization: Bearer tt_..."` — should return 403 ("This action requires an interactive session")
- [ ] Reload Settings — `Last used` should now show a recent timestamp
- [ ] Click the trash icon → confirm → key vanishes; the same `tt_...` returns 401 on subsequent use
- [ ] Try creating a key with an expiry date in the past — should reject with 400

## Migration safety
- The migration is destructive (drops `key` and `lastUsed`) but `api_keys` is empty in all environments because the model wasn't wired anywhere prior to this PR.
- Per the API package's CLAUDE.md, applying in deployed environments needs:
  ```
  npm run migrate         # dev
  npm run migrate:staging
  npm run migrate:prod
  ```
  …followed by `docker exec timetrack-api npm run db:generate && docker restart timetrack-api` so the Prisma client picks up the new fields.