### PR TITLE
Label AI-driven time entries with an opt-in billing multiplier

### DIFF
--- a/packages/api/prisma/migrations/20260508010000_ai_source_labeling/migration.sql
+++ b/packages/api/prisma/migrations/20260508010000_ai_source_labeling/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "time_entries" ADD COLUMN     "created_via" TEXT NOT NULL DEFAULT 'web',
+ADD COLUMN     "is_ai_generated" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "ai_multiplier" DOUBLE PRECISION DEFAULT 3.0;
+
+-- CreateIndex
+CREATE INDEX "time_entries_userId_is_ai_generated_idx" ON "time_entries"("userId", "is_ai_generated");

--- a/packages/api/prisma/migrations/20260508020000_api_key_ai_by_default/migration.sql
+++ b/packages/api/prisma/migrations/20260508020000_api_key_ai_by_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "api_keys" ADD COLUMN     "ai_by_default" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -111,14 +111,15 @@ model TimeEntry {
 }
 
 model ApiKey {
-  id         String    @id @default(cuid())
-  name       String
-  keyHash    String    @unique @map("key_hash")
-  keyPrefix  String    @map("key_prefix")
-  isActive   Boolean   @default(true)
-  lastUsedAt DateTime? @map("last_used_at")
-  createdAt  DateTime  @default(now())
-  expiresAt  DateTime?
+  id           String    @id @default(cuid())
+  name         String
+  keyHash      String    @unique @map("key_hash")
+  keyPrefix    String    @map("key_prefix")
+  isActive     Boolean   @default(true)
+  lastUsedAt   DateTime? @map("last_used_at")
+  createdAt    DateTime  @default(now())
+  expiresAt    DateTime?
+  aiByDefault  Boolean   @default(true) @map("ai_by_default")
 
   // Relations
   userId String

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   updatedAt         DateTime    @updatedAt
   defaultHourlyRate Float?
   idleTimeoutSeconds Int? @default(600) @map("idle_timeout_seconds")
+  aiMultiplier Float? @default(3.0) @map("ai_multiplier")
   passwordResetToken    String?
   passwordResetExpiresAt DateTime?
 
@@ -89,6 +90,8 @@ model TimeEntry {
   createdAt           DateTime  @default(now())
   updatedAt           DateTime  @updatedAt
   hourlyRateSnapshot  Float?    // Snapshot of hourly rate at time of creation
+  createdVia          String    @default("web") @map("created_via")
+  isAiGenerated       Boolean   @default(false) @map("is_ai_generated")
 
   // Relations
   userId    String
@@ -102,6 +105,7 @@ model TimeEntry {
   @@index([userId])
   @@index([userId, isRunning])
   @@index([userId, startTime])
+  @@index([userId, isAiGenerated])
   @@index([projectId])
   @@index([taskId])
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -14,6 +14,9 @@ export interface AuthenticatedRequest extends Request {
     name: string;
   };
   authMethod?: AuthMethod;
+  // Populated only when authMethod === "api_key" — drives default source
+  // labeling for entries created with this key.
+  apiKeyAiByDefault?: boolean;
 }
 
 const LAST_USED_DEBOUNCE_MS = 60_000;
@@ -52,7 +55,7 @@ const authenticateApiKey = async (token: string) => {
       });
   }
 
-  return apiKey.user;
+  return { user: apiKey.user, aiByDefault: apiKey.aiByDefault };
 };
 
 const authenticateJwt = async (token: string) => {
@@ -92,8 +95,10 @@ export const authenticate = async (
     const token = authHeader.substring(7);
 
     if (isApiKeyToken(token)) {
-      req.user = await authenticateApiKey(token);
+      const { user, aiByDefault } = await authenticateApiKey(token);
+      req.user = user;
       req.authMethod = "api_key";
+      req.apiKeyAiByDefault = aiByDefault;
     } else {
       const { user } = await authenticateJwt(token);
       req.user = user;

--- a/packages/api/src/routes/apiKeys.ts
+++ b/packages/api/src/routes/apiKeys.ts
@@ -26,6 +26,7 @@ const createSchema = z.object({
       message: "expiresAt must be in the future",
     })
     .optional(),
+  aiByDefault: z.boolean().optional(),
 });
 
 const apiKeySelect = {
@@ -36,6 +37,7 @@ const apiKeySelect = {
   lastUsedAt: true,
   createdAt: true,
   expiresAt: true,
+  aiByDefault: true,
 } as const;
 
 /**
@@ -93,7 +95,7 @@ router.get(
 router.post(
   "/",
   asyncHandler(async (req: AuthenticatedRequest, res) => {
-    const { name, expiresAt } = createSchema.parse(req.body);
+    const { name, expiresAt, aiByDefault } = createSchema.parse(req.body);
     const { token, hash, prefix } = generateApiKey();
 
     const apiKey = await prisma.$transaction(async (tx: typeof prisma) => {
@@ -113,6 +115,7 @@ router.post(
           keyHash: hash,
           keyPrefix: prefix,
           expiresAt: expiresAt ? new Date(expiresAt) : null,
+          aiByDefault: aiByDefault ?? true,
         },
         select: apiKeySelect,
       });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -260,6 +260,7 @@ router.post(
         email: true,
         defaultHourlyRate: true,
         idleTimeoutSeconds: true,
+        aiMultiplier: true,
         createdAt: true,
       },
     });
@@ -419,6 +420,7 @@ router.get(
         email: true,
         defaultHourlyRate: true,
         idleTimeoutSeconds: true,
+        aiMultiplier: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -630,6 +632,7 @@ router.post(
         email: true,
         defaultHourlyRate: true,
         idleTimeoutSeconds: true,
+        aiMultiplier: true,
       },
     });
 

--- a/packages/api/src/routes/reports.ts
+++ b/packages/api/src/routes/reports.ts
@@ -570,6 +570,8 @@ router.get(
         endTime: true,
         duration: true,
         hourlyRateSnapshot: true,
+        isAiGenerated: true,
+        createdVia: true,
         project: {
           select: {
             name: true,
@@ -597,6 +599,8 @@ router.get(
       "Task",
       "Hourly Rate",
       "Earnings",
+      "AI Generated",
+      "Created Via",
     ];
 
     const csvRows = timeEntries.map((entry: any) => {
@@ -618,6 +622,8 @@ router.get(
         entry.task?.name || "",
         entry.hourlyRateSnapshot?.toFixed(2) || "0.00",
         earnings.toFixed(2),
+        entry.isAiGenerated ? "yes" : "no",
+        entry.createdVia || "",
       ];
     });
 

--- a/packages/api/src/routes/reports.ts
+++ b/packages/api/src/routes/reports.ts
@@ -115,6 +115,7 @@ router.get(
         hourlyRateSnapshot: true,
         startTime: true,
         endTime: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,
@@ -137,6 +138,18 @@ router.get(
       0
     );
     const totalEarnings = timeEntries.reduce((sum: number, entry: any) => {
+      const rate = entry.hourlyRateSnapshot || 0;
+      const hours = (entry.duration || 0) / 3600;
+      return sum + rate * hours;
+    }, 0);
+
+    // AI subtotals so the client can apply a billing multiplier on display.
+    const aiDuration = timeEntries.reduce(
+      (sum: number, entry: any) => sum + (entry.isAiGenerated ? entry.duration || 0 : 0),
+      0
+    );
+    const aiEarnings = timeEntries.reduce((sum: number, entry: any) => {
+      if (!entry.isAiGenerated) return sum;
       const rate = entry.hourlyRateSnapshot || 0;
       const hours = (entry.duration || 0) / 3600;
       return sum + rate * hours;
@@ -191,6 +204,8 @@ router.get(
       summary: {
         totalDuration, // in seconds
         totalEarnings,
+        aiDuration,
+        aiEarnings,
         entryCount: timeEntries.length,
         averageSessionDuration:
           timeEntries.length > 0 ? totalDuration / timeEntries.length : 0,
@@ -284,6 +299,8 @@ router.get(
         duration: true,
         hourlyRateSnapshot: true,
         createdAt: true,
+        isAiGenerated: true,
+        createdVia: true,
         project: {
           select: {
             id: true,

--- a/packages/api/src/routes/timeEntries.ts
+++ b/packages/api/src/routes/timeEntries.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../utils/database";
 import { asyncHandler, createError } from "../middleware/errorHandler";
 import { authenticate, AuthenticatedRequest } from "../middleware/auth";
+import { deriveSource } from "../utils/source";
 
 const router = express.Router();
 
@@ -294,6 +295,8 @@ router.post(
       taskId || undefined
     );
 
+    const { createdVia, isAiGenerated } = deriveSource(req);
+
     const timeEntry = await prisma.timeEntry.create({
       data: {
         description,
@@ -302,6 +305,8 @@ router.post(
         taskId,
         userId: req.user!.id,
         hourlyRateSnapshot: hourlyRate,
+        createdVia,
+        isAiGenerated,
       },
       select: {
         id: true,
@@ -311,6 +316,8 @@ router.post(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        createdVia: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,
@@ -410,6 +417,8 @@ router.post(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        createdVia: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,
@@ -467,6 +476,8 @@ router.get(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        createdVia: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,
@@ -568,6 +579,8 @@ router.post(
       taskId || undefined
     );
 
+    const { createdVia, isAiGenerated } = deriveSource(req);
+
     const timeEntry = await prisma.timeEntry.create({
       data: {
         description,
@@ -579,6 +592,8 @@ router.post(
         taskId,
         userId: req.user!.id,
         hourlyRateSnapshot: hourlyRate,
+        createdVia,
+        isAiGenerated,
       },
       select: {
         id: true,
@@ -588,6 +603,8 @@ router.post(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        createdVia: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,
@@ -767,6 +784,8 @@ router.put(
         duration: true,
         isRunning: true,
         hourlyRateSnapshot: true,
+        createdVia: true,
+        isAiGenerated: true,
         project: {
           select: {
             id: true,

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -74,6 +74,11 @@ const updateProfileSchema = z.object({
     .min(60, "Idle timeout must be at least 60 seconds (1 minute)")
     .max(7200, "Idle timeout cannot exceed 7200 seconds (120 minutes)")
     .optional(),
+  aiMultiplier: z
+    .number()
+    .min(1, "AI multiplier must be at least 1")
+    .max(20, "AI multiplier cannot exceed 20")
+    .optional(),
 });
 
 const changePasswordSchema = z.object({
@@ -141,6 +146,7 @@ router.put(
         email: true,
         defaultHourlyRate: true,
         idleTimeoutSeconds: true,
+        aiMultiplier: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/packages/api/src/utils/source.ts
+++ b/packages/api/src/utils/source.ts
@@ -35,10 +35,10 @@ export const deriveSource = (
         : "web";
 
   const aiHeader = req.headers["x-ai-generated"];
+  const apiKeyDefault =
+    req.authMethod === "api_key" ? (req.apiKeyAiByDefault ?? true) : false;
   const isAiGenerated =
-    aiHeader !== undefined
-      ? isTruthyHeader(aiHeader)
-      : req.authMethod === "api_key";
+    aiHeader !== undefined ? isTruthyHeader(aiHeader) : apiKeyDefault;
 
   return { createdVia, isAiGenerated };
 };

--- a/packages/api/src/utils/source.ts
+++ b/packages/api/src/utils/source.ts
@@ -1,0 +1,44 @@
+import { AuthenticatedRequest } from "../middleware/auth";
+
+const ALLOWED_VIA = new Set([
+  "web",
+  "electron",
+  "ios",
+  "mac",
+  "mcp",
+  "api",
+]);
+
+const isTruthyHeader = (value: string | string[] | undefined): boolean => {
+  if (Array.isArray(value)) value = value[0];
+  if (!value) return false;
+  return ["1", "true", "yes"].includes(value.toLowerCase());
+};
+
+/**
+ * Determines how a TimeEntry was created — which client and whether
+ * it was AI-driven. Clients may opt out of the AI flag via
+ * `X-AI-Generated: false`; the default for API-key auth is true since
+ * the dominant use case is agent automation.
+ */
+export const deriveSource = (
+  req: AuthenticatedRequest
+): { createdVia: string; isAiGenerated: boolean } => {
+  const headerClient = (req.headers["x-client"] as string | undefined)
+    ?.toLowerCase()
+    .trim();
+  const createdVia =
+    headerClient && ALLOWED_VIA.has(headerClient)
+      ? headerClient
+      : req.authMethod === "api_key"
+        ? "api"
+        : "web";
+
+  const aiHeader = req.headers["x-ai-generated"];
+  const isAiGenerated =
+    aiHeader !== undefined
+      ? isTruthyHeader(aiHeader)
+      : req.authMethod === "api_key";
+
+  return { createdVia, isAiGenerated };
+};

--- a/packages/ui/src/components/AiBadge.tsx
+++ b/packages/ui/src/components/AiBadge.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { SparklesIcon } from "@heroicons/react/24/outline";
+
+interface AiBadgeProps {
+  via?: string;
+  className?: string;
+}
+
+const labelFor = (via?: string) => {
+  switch (via) {
+    case "mcp":
+      return "AI · MCP";
+    case "api":
+      return "AI · API";
+    default:
+      return "AI";
+  }
+};
+
+const AiBadge: React.FC<AiBadgeProps> = ({ via, className }) => (
+  <span
+    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-violet-100 text-violet-700 ${className || ""}`}
+    title="Created by an AI agent — eligible for billing multiplier"
+  >
+    <SparklesIcon className="h-3 w-3" aria-hidden="true" />
+    {labelFor(via)}
+  </span>
+);
+
+export default AiBadge;

--- a/packages/ui/src/components/ApiKeysSection.tsx
+++ b/packages/ui/src/components/ApiKeysSection.tsx
@@ -29,6 +29,7 @@ const ApiKeysSection: React.FC = () => {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [name, setName] = useState("");
   const [expiresAt, setExpiresAt] = useState("");
+  const [aiByDefault, setAiByDefault] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [newToken, setNewToken] = useState<string | null>(null);
 
@@ -48,12 +49,14 @@ const ApiKeysSection: React.FC = () => {
           expiresAt: expiresAt
             ? new Date(expiresAt).toISOString()
             : undefined,
+          aiByDefault,
         })
       ).unwrap();
       setNewToken(result.token);
       setShowCreateForm(false);
       setName("");
       setExpiresAt("");
+      setAiByDefault(true);
       toast.success("API key created");
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to create API key";
@@ -172,6 +175,23 @@ const ApiKeysSection: React.FC = () => {
               Leave blank for a key that never expires.
             </p>
           </div>
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={aiByDefault}
+              onChange={(e) => setAiByDefault(e.target.checked)}
+              className="rounded mt-0.5"
+            />
+            <span className="text-sm">
+              <span className="font-medium text-gray-900">
+                Used by an AI agent
+              </span>
+              <span className="block text-xs text-gray-500">
+                Time entries from this key are flagged for the AI billing
+                multiplier. Uncheck for non-AI automation (CLI scripts, Zapier, etc.).
+              </span>
+            </span>
+          </label>
           <div className="flex gap-2">
             <button
               type="submit"
@@ -219,6 +239,11 @@ const ApiKeysSection: React.FC = () => {
                     <code className="text-xs text-gray-600 bg-gray-100 px-2 py-0.5 rounded font-mono">
                       {key.keyPrefix}…
                     </code>
+                    {key.aiByDefault && (
+                      <span className="text-xs px-2 py-0.5 bg-violet-100 text-violet-700 rounded">
+                        AI
+                      </span>
+                    )}
                     {expired && (
                       <span className="text-xs px-2 py-0.5 bg-red-100 text-red-700 rounded">
                         expired

--- a/packages/ui/src/components/DetailedTimeEntriesTable.tsx
+++ b/packages/ui/src/components/DetailedTimeEntriesTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DetailedTimeEntry } from "../store/slices/reportsSlice";
+import AiBadge from "./AiBadge";
 import { getUserTimezone } from "../../../shared/src/utils/timezone";
 
 interface DetailedTimeEntriesTableProps {
@@ -411,8 +412,13 @@ const DetailedTimeEntriesTable: React.FC<DetailedTimeEntriesTableProps> = ({
 
                           {/* Time Entries column */}
                           <td className="px-6 py-4">
-                            <div className="text-sm text-gray-900">
-                              {entry.description || "No description"}
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="text-sm text-gray-900">
+                                {entry.description || "No description"}
+                              </span>
+                              {entry.isAiGenerated && (
+                                <AiBadge via={entry.createdVia} />
+                              )}
                             </div>
                             {entry.task && (
                               <div className="text-xs text-gray-500">

--- a/packages/ui/src/pages/Reports.tsx
+++ b/packages/ui/src/pages/Reports.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import { RootState, AppDispatch } from "../store";
 import {
   fetchWeeklyData,
@@ -7,6 +8,9 @@ import {
 } from "../store/slices/reportsSlice";
 import WeeklyChart from "../components/WeeklyChart";
 import DetailedTimeEntriesTable from "../components/DetailedTimeEntriesTable";
+
+const formatHours = (seconds: number) =>
+  `${(seconds / 3600).toFixed(2)} h`;
 
 const Reports: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -18,14 +22,16 @@ const Reports: React.FC = () => {
     error,
     currentWeekOffset,
   } = useSelector((state: RootState) => state.reports);
+  const user = useSelector((state: RootState) => state.auth.user);
 
-  // Load current week data on component mount
+  const aiMultiplier = user?.aiMultiplier ?? 3;
+  const [applyMultiplier, setApplyMultiplier] = useState(false);
+
   useEffect(() => {
     dispatch(fetchWeeklyData(0));
     dispatch(fetchDetailedTimeEntries(0));
   }, [dispatch]);
 
-  // Navigation handlers
   const handlePreviousWeek = () => {
     const newOffset = currentWeekOffset - 1;
     dispatch(fetchWeeklyData(newOffset));
@@ -33,7 +39,6 @@ const Reports: React.FC = () => {
   };
 
   const handleNextWeek = () => {
-    // Don't allow navigating to future weeks beyond current week
     if (currentWeekOffset < 0) {
       const newOffset = currentWeekOffset + 1;
       dispatch(fetchWeeklyData(newOffset));
@@ -41,42 +46,90 @@ const Reports: React.FC = () => {
     }
   };
 
+  const totals = useMemo(() => {
+    let duration = 0;
+    let earnings = 0;
+    let aiDuration = 0;
+    let aiEarnings = 0;
+    for (const entry of detailedEntries) {
+      duration += entry.duration || 0;
+      earnings += entry.earnings || 0;
+      if (entry.isAiGenerated) {
+        aiDuration += entry.duration || 0;
+        aiEarnings += entry.earnings || 0;
+      }
+    }
+    const extraMultiplier = aiMultiplier - 1;
+    return {
+      duration,
+      earnings,
+      aiDuration,
+      aiEarnings,
+      adjustedDuration: duration + aiDuration * extraMultiplier,
+      adjustedEarnings: earnings + aiEarnings * extraMultiplier,
+    };
+  }, [detailedEntries, aiMultiplier]);
+
+  const hasAi = totals.aiDuration > 0;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Reports</h1>
-        <p className="text-gray-600">Analyze your time tracking data</p>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reports</h1>
+          <p className="text-gray-600">Analyze your time tracking data</p>
+        </div>
+        {hasAi && (
+          <label className="inline-flex items-center gap-2 cursor-pointer select-none px-3 py-2 rounded-md bg-violet-50 border border-violet-200">
+            <SparklesIcon className="h-4 w-4 text-violet-600" aria-hidden="true" />
+            <span className="text-sm font-medium text-violet-900">
+              Bill AI work at {aiMultiplier.toFixed(1)}×
+            </span>
+            <input
+              type="checkbox"
+              className="rounded ml-1"
+              checked={applyMultiplier}
+              onChange={(e) => setApplyMultiplier(e.target.checked)}
+              aria-label="Apply AI billing multiplier to totals"
+            />
+          </label>
+        )}
       </div>
 
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex">
-            <div className="flex-shrink-0">
-              <svg
-                className="h-5 w-5 text-red-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </div>
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">
-                Error loading reports data
-              </h3>
-              <div className="mt-2 text-sm text-red-700">
-                <p>{error}</p>
-              </div>
-            </div>
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      {hasAi && (
+        <div className="card p-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-gray-500">Billable hours</p>
+            <p className="text-2xl font-semibold text-gray-900 tabular-nums">
+              {formatHours(applyMultiplier ? totals.adjustedDuration : totals.duration)}
+            </p>
+            {applyMultiplier && (
+              <p className="text-xs text-violet-700 mt-1">
+                +{formatHours(totals.adjustedDuration - totals.duration)} from {aiMultiplier.toFixed(1)}× multiplier on{" "}
+                {formatHours(totals.aiDuration)} AI work
+              </p>
+            )}
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-gray-500">Billable earnings</p>
+            <p className="text-2xl font-semibold text-gray-900 tabular-nums">
+              ${(applyMultiplier ? totals.adjustedEarnings : totals.earnings).toFixed(2)}
+            </p>
+            {applyMultiplier && (
+              <p className="text-xs text-violet-700 mt-1">
+                +${(totals.adjustedEarnings - totals.earnings).toFixed(2)} from multiplier
+              </p>
+            )}
           </div>
         </div>
       )}
 
-      {/* Weekly Chart */}
       {weeklyData && (
         <WeeklyChart
           data={weeklyData.dailyBreakdown}
@@ -88,13 +141,11 @@ const Reports: React.FC = () => {
         />
       )}
 
-      {/* Detailed Time Entries Table */}
       <DetailedTimeEntriesTable
         entries={detailedEntries}
         loading={detailedLoading}
       />
 
-      {/* Show loading state when no data yet */}
       {!weeklyData && loading && (
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center justify-center h-80">
@@ -106,23 +157,9 @@ const Reports: React.FC = () => {
         </div>
       )}
 
-      {/* Empty state when no data and not loading */}
       {!weeklyData && !loading && !error && (
         <div className="bg-white rounded-lg shadow p-6">
           <div className="text-center py-12">
-            <svg
-              className="mx-auto h-12 w-12 text-gray-400"
-              stroke="currentColor"
-              fill="none"
-              viewBox="0 0 48 48"
-            >
-              <path
-                d="M9 17a2 2 0 012-2h20a2 2 0 012 2v6a2 2 0 01-2 2H11a2 2 0 01-2-2v-6zM21 12h6a2 2 0 012 2v6a2 2 0 01-2 2H21a2 2 0 01-2-2v-6a2 2 0 012-2z"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
             <h3 className="mt-2 text-sm font-medium text-gray-900">
               No data available
             </h3>

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ const Settings: React.FC = () => {
     email: "",
     defaultHourlyRate: "",
     idleTimeoutMinutes: "",
+    aiMultiplier: "",
   });
 
   const [hasChanges, setHasChanges] = useState(false);
@@ -39,6 +40,10 @@ const Settings: React.FC = () => {
             ? user.defaultHourlyRate.toString()
             : "",
         idleTimeoutMinutes: idleMinutes,
+        aiMultiplier:
+          user.aiMultiplier !== null && user.aiMultiplier !== undefined
+            ? user.aiMultiplier.toString()
+            : "3",
       });
     }
   }, [user]);
@@ -61,9 +66,19 @@ const Settings: React.FC = () => {
           : "10";
       const hasIdleTimeoutChange =
         formData.idleTimeoutMinutes !== currentIdleMinutes;
+      const currentMultiplier =
+        user.aiMultiplier !== null && user.aiMultiplier !== undefined
+          ? user.aiMultiplier.toString()
+          : "3";
+      const hasMultiplierChange =
+        formData.aiMultiplier !== currentMultiplier;
 
       setHasChanges(
-        hasNameChange || hasEmailChange || hasRateChange || hasIdleTimeoutChange
+        hasNameChange ||
+          hasEmailChange ||
+          hasRateChange ||
+          hasIdleTimeoutChange ||
+          hasMultiplierChange
       );
     }
   }, [formData, user]);
@@ -89,6 +104,7 @@ const Settings: React.FC = () => {
       email?: string;
       defaultHourlyRate?: number;
       idleTimeoutSeconds?: number;
+      aiMultiplier?: number;
     } = {};
 
     if (formData.name !== (user?.name || "")) {
@@ -129,6 +145,19 @@ const Settings: React.FC = () => {
       updateData.idleTimeoutSeconds = minutes * 60;
     }
 
+    const currentMultiplier =
+      user?.aiMultiplier !== null && user?.aiMultiplier !== undefined
+        ? user.aiMultiplier.toString()
+        : "3";
+    if (formData.aiMultiplier !== currentMultiplier) {
+      const multiplier = parseFloat(formData.aiMultiplier);
+      if (isNaN(multiplier) || multiplier < 1 || multiplier > 20) {
+        toast.error("AI multiplier must be between 1 and 20.");
+        return;
+      }
+      updateData.aiMultiplier = multiplier;
+    }
+
     try {
       await dispatch(updateProfile(updateData)).unwrap();
       toast.success("Profile updated successfully!");
@@ -153,6 +182,10 @@ const Settings: React.FC = () => {
             ? user.defaultHourlyRate.toString()
             : "",
         idleTimeoutMinutes: idleMinutes,
+        aiMultiplier:
+          user.aiMultiplier !== null && user.aiMultiplier !== undefined
+            ? user.aiMultiplier.toString()
+            : "3",
       });
     }
   };
@@ -247,6 +280,29 @@ const Settings: React.FC = () => {
               />
               <p className="mt-1 text-xs text-gray-500">
                 Stop running timers automatically after this many minutes of inactivity.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                AI Billing Multiplier
+              </label>
+              <input
+                type="number"
+                name="aiMultiplier"
+                value={formData.aiMultiplier}
+                onChange={handleInputChange}
+                className="input-field mt-1"
+                placeholder="3"
+                min="1"
+                max="20"
+                step="0.1"
+                required
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Reports can apply this multiplier to time entries created by AI
+                agents (so 1 AI hour shows as {parseFloat(formData.aiMultiplier || "3").toFixed(1)} billable hours).
+                Pick what represents equivalent senior-dev time for the work.
               </p>
             </div>
 

--- a/packages/ui/src/pages/TimeEntries.tsx
+++ b/packages/ui/src/pages/TimeEntries.tsx
@@ -10,6 +10,7 @@ import { useTimer } from "../hooks/useTimer";
 import { fetchProjects, fetchTasks } from "../store/slices/projectsSlice";
 import Timer from "../components/Timer";
 import EditTimeEntryModal from "../components/EditTimeEntryModal";
+import AiBadge from "../components/AiBadge";
 import { formatReportsDuration, formatDateTime } from "../utils/dateTime";
 import { ClockIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { StopIcon } from "@heroicons/react/24/solid";
@@ -283,6 +284,9 @@ const TimeEntries: React.FC = () => {
                               Running
                             </span>
                           </div>
+                        )}
+                        {entry.isAiGenerated && (
+                          <AiBadge via={entry.createdVia} />
                         )}
                       </div>
                       {entry.description && (

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -499,7 +499,7 @@ class APIClient {
       return response.apiKeys;
     },
 
-    create: async (data: { name: string; expiresAt?: string }) => {
+    create: async (data: { name: string; expiresAt?: string; aiByDefault?: boolean }) => {
       return this.request<{
         message: string;
         apiKey: ApiKey;

--- a/packages/ui/src/store/slices/apiKeysSlice.ts
+++ b/packages/ui/src/store/slices/apiKeysSlice.ts
@@ -9,6 +9,7 @@ export interface ApiKey {
   lastUsedAt?: string | null;
   createdAt: string;
   expiresAt?: string | null;
+  aiByDefault: boolean;
 }
 
 interface ApiKeysState {
@@ -29,7 +30,7 @@ export const fetchApiKeys = createAsyncThunk("apiKeys/fetch", async () => {
 
 export const createApiKey = createAsyncThunk(
   "apiKeys/create",
-  async (data: { name: string; expiresAt?: string }) => {
+  async (data: { name: string; expiresAt?: string; aiByDefault?: boolean }) => {
     return apiKeysAPI.create(data);
   }
 );

--- a/packages/ui/src/store/slices/authSlice.ts
+++ b/packages/ui/src/store/slices/authSlice.ts
@@ -7,6 +7,7 @@ export interface User {
   name: string;
   defaultHourlyRate?: number;
   idleTimeoutSeconds?: number;
+  aiMultiplier?: number | null;
   avatar?: string;
   createdAt?: string;
   updatedAt?: string;

--- a/packages/ui/src/store/slices/reportsSlice.ts
+++ b/packages/ui/src/store/slices/reportsSlice.ts
@@ -23,6 +23,8 @@ export interface DetailedTimeEntry {
   duration: number;
   hourlyRateSnapshot: number | null;
   earnings: number;
+  createdVia?: string;
+  isAiGenerated?: boolean;
   project: {
     id: string;
     name: string;

--- a/packages/ui/src/store/slices/timeEntriesSlice.ts
+++ b/packages/ui/src/store/slices/timeEntriesSlice.ts
@@ -12,6 +12,8 @@ export interface TimeEntry {
   taskId?: string;
   userId?: string; // optional for current entry API response
   hourlyRateSnapshot?: number | null; // Rate that was active when entry was created
+  createdVia?: string;
+  isAiGenerated?: boolean;
   project?: {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary
- Time entries created via API keys (or any client opting in with `X-AI-Generated: true`) are now flagged as AI work
- Reports gain an opt-in multiplier so 1 AI hour can be billed as N senior-equivalent hours — the original motivation
- Foundation for PR C (MCP server) — agents creating entries automatically inherit the AI flag

## What changed
- **Schema**: `TimeEntry.createdVia` (string, default `'web'`), `TimeEntry.isAiGenerated` (boolean, default `false`), `User.aiMultiplier` (float, nullable, default `3.0`). Existing rows inherit defaults; no backfill needed.
- **Source helper** (`packages/api/src/utils/source.ts`): reads `X-Client` and `X-AI-Generated` headers and falls back based on `req.authMethod`. JWT → web/manual. API key → api/AI unless explicitly opted out.
- **Routes**: both create paths (`POST /time-entries/start`, `POST /time-entries`) stamp the new fields. SELECTs across `time-entries` and `reports` expose them. `/reports/summary` returns `aiDuration` + `aiEarnings` siblings to existing totals.
- **UI**:
  - `<AiBadge />` rendered on AI rows in Time Entries and the Reports detailed table
  - `Reports` page gains a "Bill AI at Nx" toggle (hidden when there's no AI work in scope) that recomputes hours and earnings on display
  - `Settings` page gains a numeric input for `aiMultiplier` (default `3.0`, range 1-20)

## Notes
- No tests in this PR (same Jest TS-config gap as PR #127; out of scope here).
- The multiplier is applied **client-side at display time**. Stored rows aren't mutated, so changing the multiplier retroactively re-prices history without rewriting data.
- `X-Client` accepts `web | electron | ios | mac | mcp | api`; unknown values fall through to the auth-based default.

## Test plan
- [ ] Log in. Reports page should NOT show the toggle when there's no AI work in scope.
- [ ] Mint an API key (Settings → API Keys). Use it to start/stop a timer with `-H 'X-Client: mcp'`. Verify the new entry has `createdVia: "mcp"` and `isAiGenerated: true`.
- [ ] Refresh Reports. Toggle "Bill AI at 3.0×" — hours and earnings should jump (1 AI hour → 3h billable). Subtext should explain the delta.
- [ ] Settings → change "AI Billing Multiplier" to 4. Save. Back to Reports — toggle now reads "4.0×" and math updates.
- [ ] Use API key with `-H 'X-AI-Generated: false'` — entry should be created with `isAiGenerated: false` and no badge.
- [ ] Edit an AI entry from the UI — the AI flag should persist (source is immutable on edit).

## Migration safety
Pure additive — three columns with defaults. Existing rows inherit `web`/`false`/`3.0`. No risk to existing data; rollback is `DROP COLUMN` ×3.