### PR TITLE
Hot-fix: MCP default URL points at prod /api base

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,7 +19,7 @@ Time entries created through this server are automatically flagged as AI work, s
 3. **Set environment variables** (in your shell or in your MCP client's config):
 
    ```bash
-   export TIMETRACK_API_URL=https://timetrack.alfredo.re
+   export TIMETRACK_API_URL=https://app.track.alfredo.re/api
    export TIMETRACK_API_KEY=tt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    ```
 
@@ -40,7 +40,7 @@ Time entries created through this server are automatically flagged as AI work, s
          "command": "node",
          "args": ["/absolute/path/to/packages/mcp/dist/index.js"],
          "env": {
-           "TIMETRACK_API_URL": "https://timetrack.alfredo.re",
+           "TIMETRACK_API_URL": "https://app.track.alfredo.re/api",
            "TIMETRACK_API_KEY": "tt_..."
          }
        }
@@ -73,7 +73,7 @@ Every request from this server sends `X-Client: mcp` so entries land with `creat
 
 | Variable             | Default                          | Notes                                       |
 | -------------------- | -------------------------------- | ------------------------------------------- |
-| `TIMETRACK_API_URL`  | `https://timetrack.alfredo.re`   | Trailing slash optional.                    |
+| `TIMETRACK_API_URL`  | `https://app.track.alfredo.re/api` | API base — the prod web app proxies `/api/*` to the API container. Trailing slash optional. For local dev: `http://localhost:3011`. |
 | `TIMETRACK_API_KEY`  | (required)                       | `tt_…` token from Settings → API Keys.      |
 
 ## Troubleshooting

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,6 +1,6 @@
 import { request } from "undici";
 
-const DEFAULT_URL = "https://timetrack.alfredo.re";
+const DEFAULT_URL = "https://app.track.alfredo.re/api";
 const CLIENT_LABEL = "mcp";
 // Hard ceilings to keep a misbehaving server (or one we've misconfigured the
 // URL to) from blowing up the agent process or leaking the key back to the LLM.


### PR DESCRIPTION
The MCP server's default \`TIMETRACK_API_URL\` was \`https://timetrack.alfredo.re\` — that host doesn't resolve. Prod is reverse-proxied at \`https://app.track.alfredo.re/api\`. Fixes the default so users without an explicit env var actually reach the API. Also updates the README example.