### PR TITLE
Allow concurrent running timers

### DIFF
--- a/packages/api/src/routes/timeEntries.ts
+++ b/packages/api/src/routes/timeEntries.ts
@@ -238,8 +238,8 @@ router.get(
  *     responses:
  *       201:
  *         description: Time entry started successfully
- *       400:
- *         description: Another time entry is already running
+ *       429:
+ *         description: Concurrent running timer limit reached
  */
 router.post(
   "/start",
@@ -250,7 +250,18 @@ router.post(
 
     // Multiple concurrent timers are intentionally allowed — needed for parallel
     // AI coding sessions on different projects. Stop them individually via
-    // POST /time-entries/:id/stop.
+    // POST /time-entries/:id/stop. Cap to keep a runaway agent (or a leaked
+    // key looping start) from filling the table.
+    const MAX_RUNNING_ENTRIES = 10;
+    const runningCount = await prisma.timeEntry.count({
+      where: { userId: req.user!.id, isRunning: true },
+    });
+    if (runningCount >= MAX_RUNNING_ENTRIES) {
+      throw createError(
+        `You can have at most ${MAX_RUNNING_ENTRIES} concurrent running timers. Stop one before starting another.`,
+        429
+      );
+    }
 
     // Validate project and task belong to user
     if (projectId) {
@@ -485,6 +496,10 @@ router.get(
       select: runningEntrySelect,
     });
 
+    // Signal that clients should migrate to /running, which returns the
+    // full set when concurrent timers exist.
+    res.set("Deprecation", "true");
+    res.set("Link", '</time-entries/running>; rel="successor-version"');
     return res.json({ timeEntry: timeEntry || null });
   })
 );

--- a/packages/api/src/routes/timeEntries.ts
+++ b/packages/api/src/routes/timeEntries.ts
@@ -248,20 +248,9 @@ router.post(
       req.body
     );
 
-    // Check if user has any running time entries
-    const runningEntry = await prisma.timeEntry.findFirst({
-      where: {
-        userId: req.user!.id,
-        isRunning: true,
-      },
-    });
-
-    if (runningEntry) {
-      throw createError(
-        "You already have a running time entry. Please stop it first.",
-        400
-      );
-    }
+    // Multiple concurrent timers are intentionally allowed — needed for parallel
+    // AI coding sessions on different projects. Stop them individually via
+    // POST /time-entries/:id/stop.
 
     // Validate project and task belong to user
     if (projectId) {
@@ -446,19 +435,43 @@ router.post(
   })
 );
 
+// Shared SELECT so /current and /running stay in lockstep.
+const runningEntrySelect = {
+  id: true,
+  description: true,
+  startTime: true,
+  endTime: true,
+  duration: true,
+  isRunning: true,
+  hourlyRateSnapshot: true,
+  createdVia: true,
+  isAiGenerated: true,
+  project: {
+    select: {
+      id: true,
+      name: true,
+      color: true,
+    },
+  },
+  task: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+} as const;
+
 /**
  * @swagger
  * /time-entries/current:
  *   get:
- *     summary: Get currently running time entry
+ *     summary: Get the most recently started running time entry (legacy single-timer endpoint)
  *     tags: [Time Entries]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Current time entry retrieved successfully
- *       404:
- *         description: No running time entry found
+ *         description: Returns the most recently started running entry, or null if none. Concurrent timers are supported — use /running for the full list.
  */
 router.get(
   "/current",
@@ -468,35 +481,39 @@ router.get(
         userId: req.user!.id,
         isRunning: true,
       },
-      select: {
-        id: true,
-        description: true,
-        startTime: true,
-        endTime: true,
-        duration: true,
-        isRunning: true,
-        hourlyRateSnapshot: true,
-        createdVia: true,
-        isAiGenerated: true,
-        project: {
-          select: {
-            id: true,
-            name: true,
-            color: true,
-          },
-        },
-        task: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-      },
+      orderBy: { startTime: "desc" },
+      select: runningEntrySelect,
     });
 
-    // Return 200 with null when no current entry exists
-    // This follows REST conventions better than 404
     return res.json({ timeEntry: timeEntry || null });
+  })
+);
+
+/**
+ * @swagger
+ * /time-entries/running:
+ *   get:
+ *     summary: List all running time entries (concurrent timers allowed)
+ *     tags: [Time Entries]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: All running entries for the user, most recently started first.
+ */
+router.get(
+  "/running",
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: {
+        userId: req.user!.id,
+        isRunning: true,
+      },
+      orderBy: { startTime: "desc" },
+      select: runningEntrySelect,
+    });
+
+    return res.json({ timeEntries });
   })
 );
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -52,18 +52,18 @@ Time entries created through this server are automatically flagged as AI work, s
 
 ## Tools
 
-| Tool             | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `current_timer`  | Get the running timer (or `null`).                                       |
-| `start_timer`    | Start a timer with optional `description`, `projectId`, `taskId`.        |
-| `stop_timer`     | Stop a timer (defaults to the currently running one if no `id` given).   |
-| `recent_entries` | List recent time entries (default 10).                                   |
-| `list_projects`  | List the user's projects.                                                |
-| `create_project` | Create a project (`name` required).                                      |
-| `list_tasks`     | List tasks, optionally filtered by `projectId`.                          |
-| `create_task`    | Create a task under a project.                                           |
-| `update_task`    | Patch a task — rename, change rate, or mark complete.                    |
-| `whoami`         | Return the authenticated user; useful for verifying the right account.   |
+| Tool             | Description                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `running_timers` | List all currently running timers. Concurrent timers are supported (parallel AI sessions).   |
+| `start_timer`    | Start a timer with optional `description`, `projectId`, `taskId`. Doesn't stop existing ones. |
+| `stop_timer`     | Stop a timer. If `id` is omitted and exactly one timer is running, that one is stopped.      |
+| `recent_entries` | List recent time entries (default 10).                                                       |
+| `list_projects`  | List the user's projects.                                                                    |
+| `create_project` | Create a project (`name` required).                                                          |
+| `list_tasks`     | List tasks, optionally filtered by `projectId`.                                              |
+| `create_task`    | Create a task under a project.                                                               |
+| `update_task`    | Patch a task — rename, change rate, or mark complete.                                        |
+| `whoami`         | Return the authenticated user; useful for verifying the right account.                       |
 
 ## How AI labeling works
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -101,8 +101,11 @@ export class TimeTrackClient {
       endTime ? { endTime } : {}
     );
   }
-  currentTimer() {
-    return this.send<{ timeEntry: unknown | null }>("GET", "/time-entries/current");
+  runningTimers() {
+    return this.send<{ timeEntries: Array<{ id: string; [k: string]: unknown }> }>(
+      "GET",
+      "/time-entries/running"
+    );
   }
   recentEntries(limit = 10) {
     return this.send<{ timeEntries: unknown[] }>(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -15,15 +15,15 @@ interface ToolDef {
 
 const tools: ToolDef[] = [
   {
-    name: "current_timer",
+    name: "running_timers",
     description:
-      "Get the currently running timer (if any). Returns null when nothing is running.",
+      "List all currently running timers (most recently started first). Concurrent timers are supported — multiple AI sessions on different projects can each have their own running timer.",
     inputSchema: { type: "object", properties: {}, additionalProperties: false },
   },
   {
     name: "start_timer",
     description:
-      "Start a new timer. If a timer is already running, the request will be rejected — stop it first with stop_timer. Returns the created time entry.",
+      "Start a new timer. Concurrent timers are allowed — this never auto-stops an existing one. Returns the created time entry.",
     inputSchema: {
       type: "object",
       properties: {
@@ -40,11 +40,11 @@ const tools: ToolDef[] = [
   {
     name: "stop_timer",
     description:
-      "Stop a running timer. If no id is supplied, stops the currently running one (call current_timer first if you need to confirm which).",
+      "Stop a running timer. Pass the entry id. If id is omitted and exactly one timer is running, that one is stopped; otherwise the call returns the list of running timers so you can pick.",
     inputSchema: {
       type: "object",
       properties: {
-        id: { type: "string", description: "Time entry id. Omit to stop the current timer." },
+        id: { type: "string", description: "Time entry id from running_timers." },
         endTime: {
           type: "string",
           description:
@@ -173,8 +173,8 @@ async function main() {
     const a: Record<string, unknown> = args;
     try {
       switch (name) {
-        case "current_timer":
-          return ok(await client.currentTimer());
+        case "running_timers":
+          return ok(await client.runningTimers());
         case "start_timer":
           return ok(
             await client.startTimer({
@@ -186,13 +186,19 @@ async function main() {
         case "stop_timer": {
           let id = a.id as string | undefined;
           if (!id) {
-            const current = (await client.currentTimer()) as {
-              timeEntry?: { id?: string } | null;
-            };
-            id = current.timeEntry?.id;
-            if (!id) {
-              return ok({ message: "No timer is currently running." });
+            const running = await client.runningTimers();
+            const entries = running.timeEntries ?? [];
+            if (entries.length === 0) {
+              return ok({ message: "No timers are currently running." });
             }
+            if (entries.length > 1) {
+              return ok({
+                message:
+                  "Multiple timers are running — call stop_timer again with the id of the one you want to stop.",
+                runningTimers: entries,
+              });
+            }
+            id = entries[0].id;
           }
           return ok(await client.stopTimer(id, a.endTime as string | undefined));
         }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -189,14 +189,28 @@ async function main() {
             const running = await client.runningTimers();
             const entries = running.timeEntries ?? [];
             if (entries.length === 0) {
-              return ok({ message: "No timers are currently running." });
+              // Returning isError tells the agent the action did NOT complete,
+              // rather than letting it report "stopped" to the user.
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "No timers are currently running — nothing to stop.",
+                  },
+                ],
+                isError: true,
+              };
             }
             if (entries.length > 1) {
-              return ok({
-                message:
-                  "Multiple timers are running — call stop_timer again with the id of the one you want to stop.",
-                runningTimers: entries,
-              });
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Ambiguous: ${entries.length} timers are running. Call stop_timer again with one of these ids:\n${JSON.stringify(entries, null, 2)}`,
+                  },
+                ],
+                isError: true,
+              };
             }
             id = entries[0].id;
           }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,7 +6,7 @@ import { getCurrentUser } from "./store/slices/authSlice";
 import { useTimer } from "./hooks/useTimer";
 import { useSocket } from "./hooks/useSocket";
 import { fetchProjects } from "./store/slices/projectsSlice";
-import { fetchCurrentEntry, syncTimer } from "./store/slices/timerSlice";
+import { fetchRunningEntries, syncTimer } from "./store/slices/timerSlice";
 import { isElectron } from "./utils/platform";
 import { wasRecentlyIdleStopped } from "./hooks/useIdleMonitor";
 import Layout from "./components/Layout";
@@ -169,7 +169,7 @@ function AppContent() {
   // Initialize timer when user is authenticated
   useEffect(() => {
     if (isAuthenticated) {
-      dispatch(fetchCurrentEntry());
+      dispatch(fetchRunningEntries());
     }
   }, [dispatch, isAuthenticated]);
 
@@ -190,7 +190,7 @@ function AppContent() {
       if (now - lastSyncTs < DEDUPE_MS) return;
       lastSyncTs = now;
       dispatch(syncTimer());
-      dispatch(fetchCurrentEntry());
+      dispatch(fetchRunningEntries());
     };
 
     const handleVisibilityChange = () => {

--- a/packages/ui/src/components/RunningTimersStack.tsx
+++ b/packages/ui/src/components/RunningTimersStack.tsx
@@ -4,6 +4,7 @@ import { StopIcon, ClockIcon } from "@heroicons/react/24/solid";
 import { AppDispatch, RootState } from "../store";
 import {
   selectRunningEntries,
+  selectStoppingIds,
   stopTimer,
 } from "../store/slices/timerSlice";
 import { fetchDashboardEarnings } from "../store/slices/dashboardSlice";
@@ -26,7 +27,7 @@ const RunningTimersStack: React.FC = () => {
   const elapsedById = useSelector(
     (state: RootState) => state.timer.elapsedById
   );
-  const loading = useSelector((state: RootState) => state.timer.loading);
+  const stoppingIds = useSelector(selectStoppingIds);
 
   if (entries.length === 0) return null;
 
@@ -44,11 +45,18 @@ const RunningTimersStack: React.FC = () => {
     <div className="card overflow-hidden">
       <div className="px-6 py-3 border-b border-gray-200 flex items-center justify-between">
         <h3 className="text-sm font-medium text-gray-900 flex items-center gap-2">
-          <ClockIcon className="h-4 w-4 text-green-600 animate-pulse" />
+          <ClockIcon
+            className="h-4 w-4 text-green-600 animate-pulse"
+            aria-hidden="true"
+          />
           Running now ({entries.length})
         </h3>
       </div>
-      <ul className="divide-y divide-gray-100">
+      <ul
+        className="divide-y divide-gray-100"
+        aria-label="Running timers"
+        aria-live="polite"
+      >
         {entries.map((entry) => {
           const elapsed = elapsedById[entry.id] ?? entry.duration ?? 0;
           const project = entry.project;
@@ -95,13 +103,13 @@ const RunningTimersStack: React.FC = () => {
               <button
                 type="button"
                 onClick={() => handleStop(entry.id)}
-                disabled={loading}
+                disabled={!!stoppingIds[entry.id]}
                 className="ml-1 inline-flex items-center gap-1 px-2 py-1 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
                 title={`Stop ${project?.name || "timer"}`}
                 aria-label={`Stop timer for ${project?.name || "entry"}`}
               >
-                <StopIcon className="h-4 w-4" />
-                Stop
+                <StopIcon className="h-4 w-4" aria-hidden="true" />
+                {stoppingIds[entry.id] ? "Stopping..." : "Stop"}
               </button>
             </li>
           );

--- a/packages/ui/src/components/RunningTimersStack.tsx
+++ b/packages/ui/src/components/RunningTimersStack.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { StopIcon, ClockIcon } from "@heroicons/react/24/solid";
+import { AppDispatch, RootState } from "../store";
+import {
+  selectRunningEntries,
+  stopTimer,
+} from "../store/slices/timerSlice";
+import { fetchDashboardEarnings } from "../store/slices/dashboardSlice";
+import { fetchTimeEntries } from "../store/slices/timeEntriesSlice";
+import AiBadge from "./AiBadge";
+
+const pad = (n: number) => n.toString().padStart(2, "0");
+
+const formatElapsed = (totalSeconds: number) => {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) totalSeconds = 0;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+};
+
+const RunningTimersStack: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const entries = useSelector(selectRunningEntries);
+  const elapsedById = useSelector(
+    (state: RootState) => state.timer.elapsedById
+  );
+  const loading = useSelector((state: RootState) => state.timer.loading);
+
+  if (entries.length === 0) return null;
+
+  const handleStop = async (id: string) => {
+    try {
+      await dispatch(stopTimer(id)).unwrap();
+      dispatch(fetchDashboardEarnings());
+      dispatch(fetchTimeEntries({ limit: 10 }));
+    } catch {
+      // Errors surface via the timer slice's error state.
+    }
+  };
+
+  return (
+    <div className="card overflow-hidden">
+      <div className="px-6 py-3 border-b border-gray-200 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-900 flex items-center gap-2">
+          <ClockIcon className="h-4 w-4 text-green-600 animate-pulse" />
+          Running now ({entries.length})
+        </h3>
+      </div>
+      <ul className="divide-y divide-gray-100">
+        {entries.map((entry) => {
+          const elapsed = elapsedById[entry.id] ?? entry.duration ?? 0;
+          const project = entry.project;
+          const task = entry.task;
+          return (
+            <li
+              key={entry.id}
+              className="px-6 py-3 flex items-center gap-3 flex-wrap"
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                {project?.color && (
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: project.color }}
+                  />
+                )}
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-gray-900 flex items-center gap-2 flex-wrap">
+                    <span className="truncate">
+                      {project?.name || "No project"}
+                    </span>
+                    {task?.name && (
+                      <>
+                        <span className="text-gray-400">·</span>
+                        <span className="text-gray-700 truncate">
+                          {task.name}
+                        </span>
+                      </>
+                    )}
+                    {entry.isAiGenerated && (
+                      <AiBadge via={entry.createdVia} />
+                    )}
+                  </div>
+                  {entry.description && (
+                    <p className="text-xs text-gray-500 truncate">
+                      {entry.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="font-mono font-medium tabular-nums text-gray-900 text-sm">
+                {formatElapsed(elapsed)}
+              </div>
+              <button
+                type="button"
+                onClick={() => handleStop(entry.id)}
+                disabled={loading}
+                className="ml-1 inline-flex items-center gap-1 px-2 py-1 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+                title={`Stop ${project?.name || "timer"}`}
+                aria-label={`Stop timer for ${project?.name || "entry"}`}
+              >
+                <StopIcon className="h-4 w-4" />
+                Stop
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default RunningTimersStack;

--- a/packages/ui/src/components/Timer.tsx
+++ b/packages/ui/src/components/Timer.tsx
@@ -6,7 +6,7 @@ import { fetchProjects } from "../store/slices/projectsSlice";
 import { fetchTasks } from "../store/slices/projectsSlice";
 import { fetchTimeEntries } from "../store/slices/timeEntriesSlice";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
-import { StopIcon, PlayIcon } from "@heroicons/react/24/solid";
+import { PlayIcon } from "@heroicons/react/24/solid";
 import ResumeLastTimer from "./ResumeLastTimer";
 
 interface TimerProps {
@@ -19,22 +19,13 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
     (state: RootState) => state.projects
   );
 
-  // Use centralized timer hook
-  const {
-    isRunning,
-    currentEntry,
-    elapsedTime,
-    loading,
-    error,
-    startTimer,
-    stopTimer,
-    formatTime,
-  } = useTimer();
+  // Use centralized timer hook (we no longer render the running state here —
+  // see RunningTimersStack — but we still need loading/error/startTimer)
+  const { loading, error, startTimer } = useTimer();
 
   const [selectedProjectId, setSelectedProjectId] = useState<string>("");
   const [selectedTaskId, setSelectedTaskId] = useState<string>("");
   const [description, setDescription] = useState<string>("");
-  const [showProjectSelector, setShowProjectSelector] = useState(false);
 
   // Load initial data
   useEffect(() => {
@@ -49,41 +40,16 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
     }
   }, [selectedProjectId, dispatch]);
 
-  // Set current project/task if timer is running
-  useEffect(() => {
-    if (currentEntry) {
-      setSelectedProjectId(currentEntry.project?.id || currentEntry.projectId || "");
-      setSelectedTaskId(currentEntry.task?.id || currentEntry.taskId || "");
-      setDescription(currentEntry.description || "");
-    } else {
-      // Clear local state when timer is stopped (currentEntry becomes null)
-      setSelectedProjectId("");
-      setSelectedTaskId("");
-      setDescription("");
-    }
-  }, [currentEntry]);
-
   const handleStartTimer = async () => {
-    if (!selectedProjectId) {
-      setShowProjectSelector(true);
-      return;
-    }
-
+    if (!selectedProjectId) return;
     try {
       await startTimer({
         projectId: selectedProjectId,
         taskId: selectedTaskId || undefined,
         description: description || undefined,
       });
-      setShowProjectSelector(false);
-    } catch (error) {
-      // Error is already logged in the hook
-    }
-  };
-
-  const handleStopTimer = async () => {
-    try {
-      await stopTimer();
+      // Reset the form so the next start isn't pre-filled with the same values.
+      setDescription("");
     } catch (error) {
       // Error is already logged in the hook
     }
@@ -92,22 +58,18 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
   // Handle form submission (for Enter key support)
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!isRunning && !loading && selectedProjectId) {
+    if (!loading && selectedProjectId) {
       handleStartTimer();
     }
   };
 
   // Handle Enter key in form fields
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !isRunning && !loading && selectedProjectId) {
+    if (e.key === "Enter" && !loading && selectedProjectId) {
       e.preventDefault();
       handleStartTimer();
     }
   };
-
-  const selectedProject = Array.isArray(projects)
-    ? projects.find((p) => p.id === selectedProjectId)
-    : undefined;
 
   // Since we fetch tasks with a specific projectId, all tasks in the store
   // should already be for the selected project, no need to filter again
@@ -115,41 +77,7 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
 
   return (
     <div className={`${className}`}>
-      {/* Timer Display */}
-      <div className="text-center mb-6">
-        <div className="timer-display mb-2">{formatTime(elapsedTime)}</div>
-        {currentEntry && (currentEntry.project || selectedProject) && (
-          <div className="text-sm text-gray-600 line-clamp-2 max-w-xs mx-auto">
-            <span className="inline-flex items-center gap-1.5">
-              {(currentEntry.project?.color || selectedProject?.color) && (
-                <span
-                  className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: currentEntry.project?.color || selectedProject?.color }}
-                />
-              )}
-              <span className="font-medium">
-                {currentEntry.project?.name || selectedProject?.name}
-              </span>
-              {(currentEntry.task || currentEntry.taskId) && (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span>
-                    {currentEntry.task?.name ||
-                      availableTasks.find((t) => t.id === currentEntry.taskId)?.name}
-                  </span>
-                </>
-              )}
-            </span>
-            {description && (
-              <span className="block text-gray-500 mt-0.5">{description}</span>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Project Selector (shown when not running or when no project selected) */}
-      {(!isRunning || showProjectSelector) && (
-        <form onSubmit={handleFormSubmit} className="space-y-4 mb-6">
+      <form onSubmit={handleFormSubmit} className="space-y-4 mb-6">
           <div>
             <label
               htmlFor="project"
@@ -225,7 +153,6 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
             />
           </div>
         </form>
-      )}
 
       {/* Error Message */}
       {error && (
@@ -236,40 +163,15 @@ const Timer: React.FC<TimerProps> = ({ className = "" }) => {
 
       {/* Timer Controls */}
       <div className="flex gap-3">
-        {!isRunning ? (
-          <button
-            onClick={handleStartTimer}
-            disabled={loading || !selectedProjectId}
-            className="btn-primary flex-1 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            type="submit"
-            form={!isRunning || showProjectSelector ? undefined : "timer-form"}
-          >
-            <PlayIcon className="h-4 w-4" />
-            {loading ? "Starting..." : "Start Timer"}
-          </button>
-        ) : (
-          <>
-            <button
-              onClick={handleStopTimer}
-              disabled={loading}
-              className="btn-danger flex-1 flex items-center justify-center gap-2"
-            >
-              <StopIcon className="h-4 w-4" />
-              {loading ? "Stopping..." : "Stop Timer"}
-              <kbd className="ml-2 px-1.5 py-0.5 text-[10px] font-mono text-red-400 bg-red-50 border border-red-200 rounded hidden sm:inline">
-                Space
-              </kbd>
-            </button>
-            {showProjectSelector && (
-              <button
-                onClick={() => setShowProjectSelector(false)}
-                className="btn-secondary px-4"
-              >
-                Cancel
-              </button>
-            )}
-          </>
-        )}
+        <button
+          onClick={handleStartTimer}
+          disabled={loading || !selectedProjectId}
+          className="btn-primary flex-1 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          type="submit"
+        >
+          <PlayIcon className="h-4 w-4" />
+          {loading ? "Starting..." : "Start Timer"}
+        </button>
       </div>
 
       {/* Resume Last Timer Component */}

--- a/packages/ui/src/components/TimerWidget.tsx
+++ b/packages/ui/src/components/TimerWidget.tsx
@@ -19,6 +19,9 @@ const TimerWidget: React.FC = () => {
     stopTimer,
     formatTimeCompact,
   } = useTimer();
+  const runningCount = useSelector(
+    (state: RootState) => state.timer.runningEntries.length
+  );
 
   const handleStopTimer = async () => {
     try {
@@ -61,18 +64,26 @@ const TimerWidget: React.FC = () => {
       <button
         onClick={handleTimerClick}
         className="flex items-center gap-2 px-3 py-2 text-sm bg-green-50 text-green-700 hover:bg-green-100 rounded-lg transition-colors"
-        title={`Timer running${
-          currentProject ? ` - ${currentProject.name}` : ""
-        }`}
+        title={
+          runningCount > 1
+            ? `${runningCount} timers running`
+            : `Timer running${currentProject ? ` - ${currentProject.name}` : ""}`
+        }
       >
         <ClockIcon className="h-4 w-4 animate-pulse" />
         <span className="font-mono font-medium tabular-nums">
           {formatTimeCompact(elapsedTime)}
         </span>
-        {currentProject && (
+        {runningCount > 1 ? (
           <span className="hidden md:inline text-xs">
-            - {currentProject.name}
+            · {runningCount} running
           </span>
+        ) : (
+          currentProject && (
+            <span className="hidden md:inline text-xs">
+              - {currentProject.name}
+            </span>
+          )
         )}
       </button>
 

--- a/packages/ui/src/components/TimerWidget.tsx
+++ b/packages/ui/src/components/TimerWidget.tsx
@@ -87,15 +87,19 @@ const TimerWidget: React.FC = () => {
         )}
       </button>
 
-      {/* Stop button */}
-      <button
-        onClick={handleStopTimer}
-        disabled={loading}
-        className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
-        title="Stop timer"
-      >
-        <StopIcon className="h-4 w-4" />
-      </button>
+      {/* Stop button — hidden when multiple timers run to avoid silently
+          stopping the wrong one. User picks from the Dashboard stack instead. */}
+      {runningCount <= 1 && (
+        <button
+          onClick={handleStopTimer}
+          disabled={loading}
+          className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+          title="Stop timer"
+          aria-label="Stop running timer"
+        >
+          <StopIcon className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/ui/src/components/electron/ElectronApp.tsx
+++ b/packages/ui/src/components/electron/ElectronApp.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "../../store";
 import { getCurrentUser } from "../../store/slices/authSlice";
-import { fetchCurrentEntry } from "../../store/slices/timerSlice";
+import { fetchRunningEntries } from "../../store/slices/timerSlice";
 import { useTimer } from "../../hooks/useTimer";
 import ElectronTimerForm from "./ElectronTimerForm";
 import ElectronTimerDisplay from "./ElectronTimerDisplay";
@@ -32,7 +32,7 @@ const ElectronApp: React.FC = () => {
   // Initialize timer when user is authenticated
   useEffect(() => {
     if (isAuthenticated) {
-      dispatch(fetchCurrentEntry());
+      dispatch(fetchRunningEntries());
     }
   }, [dispatch, isAuthenticated]);
 

--- a/packages/ui/src/components/electron/ElectronTimerDisplay.tsx
+++ b/packages/ui/src/components/electron/ElectronTimerDisplay.tsx
@@ -15,6 +15,9 @@ const ElectronTimerDisplay: React.FC = () => {
     formatTime,
     loading,
   } = useTimer();
+  const runningCount = useSelector(
+    (state: RootState) => state.timer.runningEntries.length
+  );
 
   const handleStopTimer = async () => {
     try {
@@ -42,8 +45,18 @@ const ElectronTimerDisplay: React.FC = () => {
         </div>
         <div className="flex items-center justify-center gap-1 text-green-600">
           <ClockIcon className="h-4 w-4 animate-pulse" />
-          <span className="text-sm">Timer running</span>
+          <span className="text-sm">
+            {runningCount > 1
+              ? `${runningCount} timers running`
+              : "Timer running"}
+          </span>
         </div>
+        {runningCount > 1 && (
+          <p className="mt-1 text-xs text-amber-700">
+            Showing the most recently started. Open the web app to manage the
+            others.
+          </p>
+        )}
       </div>
 
       {/* Project Info */}

--- a/packages/ui/src/hooks/useIdleMonitor.ts
+++ b/packages/ui/src/hooks/useIdleMonitor.ts
@@ -28,7 +28,12 @@ export function wasRecentlyIdleStopped(): boolean {
  * that was hidden longer than the idle threshold, auto-stops the timer.
  */
 export function useIdleMonitor(): void {
-  const isRunning = useSelector((state: RootState) => state.timer.isRunning);
+  // Only watch for idle when there's at least one stoppable (non-MCP) timer.
+  // Without this gate, an all-MCP set of timers would have the interval
+  // polling forever and never doing anything.
+  const hasStoppableTimer = useSelector((state: RootState) =>
+    state.timer.runningEntries.some((e) => e.createdVia !== "mcp")
+  );
   const idleTimeoutSeconds = useSelector(
     (state: RootState) => state.auth.user?.idleTimeoutSeconds ?? 0
   );
@@ -47,11 +52,13 @@ export function useIdleMonitor(): void {
       if (hasStoppedRef.current) return;
 
       const state = store.getState();
-      // Stop only human-started timers. AI-driven entries (MCP / API key with
-      // aiByDefault) run unattended on the user's behalf and shouldn't be
-      // killed because the user's idle in the browser.
+      // Skip MCP-driven entries — those are unattended agent sessions that
+      // shouldn't die because the human's browser tab is idle. Note we key
+      // on createdVia (specifically "mcp") rather than isAiGenerated: the
+      // latter is a billing label that a script user can set without
+      // implying the timer is actually agent-driven.
       const stoppable = state.timer.runningEntries.filter(
-        (e) => !e.isAiGenerated
+        (e) => e.createdVia !== "mcp"
       );
       if (stoppable.length === 0) return;
 
@@ -76,7 +83,7 @@ export function useIdleMonitor(): void {
   );
 
   useEffect(() => {
-    if (!isRunning || !idleTimeoutSeconds) return;
+    if (!hasStoppableTimer || !idleTimeoutSeconds) return;
 
     // Reset stop guard when effect re-runs (timer started again)
     hasStoppedRef.current = false;
@@ -136,5 +143,5 @@ export function useIdleMonitor(): void {
       clearInterval(checkInterval);
       if (throttleTimer) clearTimeout(throttleTimer);
     };
-  }, [isRunning, idleTimeoutSeconds, resetActivity, handleIdleStop]);
+  }, [hasStoppableTimer, idleTimeoutSeconds, resetActivity, handleIdleStop]);
 }

--- a/packages/ui/src/hooks/useIdleMonitor.ts
+++ b/packages/ui/src/hooks/useIdleMonitor.ts
@@ -47,25 +47,31 @@ export function useIdleMonitor(): void {
       if (hasStoppedRef.current) return;
 
       const state = store.getState();
-      const currentEntry = state.timer.currentEntry;
-      if (!currentEntry || !state.timer.isRunning) return;
+      // Stop only human-started timers. AI-driven entries (MCP / API key with
+      // aiByDefault) run unattended on the user's behalf and shouldn't be
+      // killed because the user's idle in the browser.
+      const stoppable = state.timer.runningEntries.filter(
+        (e) => !e.isAiGenerated
+      );
+      if (stoppable.length === 0) return;
 
       hasStoppedRef.current = true;
       lastIdleStopAt = Date.now();
       const idleMinutes = Math.round(idleMs / 60000);
 
-      store.dispatch(stopTimer(currentEntry.id)).then(() => {
-        store.dispatch(fetchDashboardEarnings());
-        store.dispatch(fetchTimeEntries({ limit: 10 }));
-      });
+      Promise.all(stoppable.map((e) => store.dispatch(stopTimer(e.id)))).then(
+        () => {
+          store.dispatch(fetchDashboardEarnings());
+          store.dispatch(fetchTimeEntries({ limit: 10 }));
+        }
+      );
 
+      const count = stoppable.length;
       toast(
-        `Timer stopped due to inactivity${idleMinutes > 0 ? ` (${idleMinutes} min)` : ""}`,
+        `${count > 1 ? `${count} timers` : "Timer"} stopped due to inactivity${idleMinutes > 0 ? ` (${idleMinutes} min)` : ""}`,
         { duration: 15000 }
       );
     },
-    // Empty deps: reads store.getState() directly to avoid stale closures,
-    // same pattern as useBeforeUnload.
     []
   );
 

--- a/packages/ui/src/hooks/useSocket.ts
+++ b/packages/ui/src/hooks/useSocket.ts
@@ -68,7 +68,7 @@ export function useSocket() {
         dispatch(timerStartedFromSocket(entry));
       },
       onTimeEntryStopped: (entry) => {
-        dispatch(timerStoppedFromSocket());
+        dispatch(timerStoppedFromSocket({ id: entry.id }));
         dispatch(entryUpdatedFromSocket(entry));
         debouncedFetchEarnings();
       },

--- a/packages/ui/src/hooks/useTimer.ts
+++ b/packages/ui/src/hooks/useTimer.ts
@@ -6,7 +6,7 @@ import {
   stopTimer as stopTimerAction,
   tick,
   syncTimer,
-  fetchCurrentEntry,
+  fetchRunningEntries,
 } from "../store/slices/timerSlice";
 import { fetchDashboardEarnings } from "../store/slices/dashboardSlice";
 import { fetchTimeEntries } from "../store/slices/timeEntriesSlice";
@@ -114,7 +114,7 @@ export const useTimer = (): UseTimerReturn => {
   // Initialize timer (fetch current entry if any)
   const initializeTimer = useCallback(async (): Promise<void> => {
     try {
-      await dispatch(fetchCurrentEntry()).unwrap();
+      await dispatch(fetchRunningEntries()).unwrap();
     } catch (error) {
       console.error("Failed to initialize timer:", error);
       // Don't throw here as this is initialization and shouldn't break the app

--- a/packages/ui/src/pages/Dashboard.tsx
+++ b/packages/ui/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
 import { fetchTimeEntries, TimeEntry } from "../store/slices/timeEntriesSlice";
 import { fetchProjects } from "../store/slices/projectsSlice";
 import Timer from "../components/Timer";
+import RunningTimersStack from "../components/RunningTimersStack";
 import { formatReportsDuration, formatDateTime } from "../utils/dateTime";
 import { ClockIcon } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
@@ -101,12 +102,15 @@ const Dashboard: React.FC = () => {
         <p className="text-gray-600">Track your time and monitor earnings</p>
       </div>
 
+      {/* Running timers (zero or more) */}
+      <RunningTimersStack />
+
       {/* Timer and Earnings Section */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-        {/* Timer Section */}
+        {/* Start-a-timer form */}
         <div className="card p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">
-            Time Tracker
+            Start a timer
           </h2>
           <Timer />
         </div>

--- a/packages/ui/src/pages/__tests__/TimeEntries.test.tsx
+++ b/packages/ui/src/pages/__tests__/TimeEntries.test.tsx
@@ -48,6 +48,7 @@ const createTestStore = (initialState = {}) => {
       timer: {
         runningEntries: [],
         elapsedById: {},
+        stoppingIds: {},
         isRunning: false,
         elapsedTime: 0,
         currentEntry: null,

--- a/packages/ui/src/pages/__tests__/TimeEntries.test.tsx
+++ b/packages/ui/src/pages/__tests__/TimeEntries.test.tsx
@@ -46,6 +46,8 @@ const createTestStore = (initialState = {}) => {
         hasCheckedAuth: true,
       },
       timer: {
+        runningEntries: [],
+        elapsedById: {},
         isRunning: false,
         elapsedTime: 0,
         currentEntry: null,

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -334,6 +334,14 @@ class APIClient {
       return this.request<TimeEntry | null>("GET", "/time-entries/current");
     },
 
+    getRunningEntries: async () => {
+      const response = await this.request<{ timeEntries: TimeEntry[] }>(
+        "GET",
+        "/time-entries/running"
+      );
+      return response.timeEntries;
+    },
+
     createTimeEntry: async (entryData: {
       description?: string;
       startTime: string;

--- a/packages/ui/src/store/slices/__tests__/timerSlice.test.ts
+++ b/packages/ui/src/store/slices/__tests__/timerSlice.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import timerSlice, {
   startTimer,
   stopTimer,
-  fetchCurrentEntry,
+  fetchRunningEntries,
   tick,
   resetTimer,
   clearError,
@@ -33,6 +33,9 @@ describe("timerSlice", () => {
       const state = store.getState().timer;
 
       expect(state).toEqual({
+        runningEntries: [],
+        elapsedById: {},
+        stoppingIds: {},
         isRunning: false,
         currentEntry: null,
         elapsedTime: 0,
@@ -270,7 +273,7 @@ describe("timerSlice", () => {
     });
   });
 
-  describe("fetchCurrentEntry async thunk", () => {
+  describe("fetchRunningEntries async thunk", () => {
     it("should handle fetching existing current entry", async () => {
       const mockEntry = {
         id: "current-entry",
@@ -289,9 +292,9 @@ describe("timerSlice", () => {
 
       const store = createTestStore();
 
-      const result = await store.dispatch(fetchCurrentEntry());
+      const result = await store.dispatch(fetchRunningEntries());
 
-      expect(result.type).toBe("timer/fetchCurrentEntry/fulfilled");
+      expect(result.type).toBe("timer/fetchRunningEntries/fulfilled");
 
       const state = store.getState().timer;
       expect(state.isRunning).toBe(true);
@@ -302,9 +305,9 @@ describe("timerSlice", () => {
     it("should handle no current entry", async () => {
       const store = createTestStore();
 
-      const result = await store.dispatch(fetchCurrentEntry());
+      const result = await store.dispatch(fetchRunningEntries());
 
-      expect(result.type).toBe("timer/fetchCurrentEntry/fulfilled");
+      expect(result.type).toBe("timer/fetchRunningEntries/fulfilled");
 
       const state = store.getState().timer;
       expect(state.isRunning).toBe(false);
@@ -320,9 +323,9 @@ describe("timerSlice", () => {
       // Explicitly set mock to null to get { timeEntry: null } response
       setMockCurrentEntry(null);
 
-      const result = await store.dispatch(fetchCurrentEntry());
+      const result = await store.dispatch(fetchRunningEntries());
 
-      expect(result.type).toBe("timer/fetchCurrentEntry/fulfilled");
+      expect(result.type).toBe("timer/fetchRunningEntries/fulfilled");
       expect(result.payload).toBe(null);
 
       const state = store.getState().timer;
@@ -350,10 +353,10 @@ describe("timerSlice", () => {
         })
       );
 
-      const result = await store.dispatch(fetchCurrentEntry());
+      const result = await store.dispatch(fetchRunningEntries());
 
       // Should handle 404 gracefully and return fulfilled with null
-      expect(result.type).toBe("timer/fetchCurrentEntry/fulfilled");
+      expect(result.type).toBe("timer/fetchRunningEntries/fulfilled");
       expect(result.payload).toBe(null);
 
       const state = store.getState().timer;
@@ -381,7 +384,7 @@ describe("timerSlice", () => {
 
       const store = createTestStore();
 
-      await store.dispatch(fetchCurrentEntry());
+      await store.dispatch(fetchRunningEntries());
 
       const state = store.getState().timer;
       expect(state.elapsedTime).toBeGreaterThanOrEqual(9); // Should be around 10 seconds

--- a/packages/ui/src/store/slices/timerSlice.ts
+++ b/packages/ui/src/store/slices/timerSlice.ts
@@ -3,21 +3,50 @@ import { timeEntriesAPI } from "../../services/api";
 import { TimeEntry } from "./timeEntriesSlice";
 
 interface TimerState {
+  // Source of truth: all currently running timers, most recently started first.
+  // Multiple concurrent timers are allowed so parallel AI sessions on different
+  // projects each get their own row.
+  runningEntries: TimeEntry[];
+  // Per-entry live elapsed seconds, driven by tick/syncTimer.
+  elapsedById: Record<string, number>;
+
+  // Backwards-compat mirrors of the most recent running entry. Old consumers
+  // (Timer widget, header, electron display) keep reading these unchanged.
   isRunning: boolean;
   currentEntry: TimeEntry | null;
-  elapsedTime: number; // in seconds
+  elapsedTime: number;
+
   loading: boolean;
   fetchingCurrentEntry: boolean;
   error: string | null;
 }
 
 const initialState: TimerState = {
+  runningEntries: [],
+  elapsedById: {},
   isRunning: false,
   currentEntry: null,
   elapsedTime: 0,
   loading: false,
   fetchingCurrentEntry: false,
   error: null,
+};
+
+const elapsedFromStart = (entry: TimeEntry): number => {
+  if (!entry.startTime) return entry.duration || 0;
+  const start = new Date(entry.startTime).getTime();
+  const now = Date.now();
+  if (!Number.isFinite(start) || !Number.isFinite(now) || start > now) {
+    return entry.duration || 0;
+  }
+  return Math.floor((now - start) / 1000);
+};
+
+const syncMirrors = (state: TimerState) => {
+  const primary = state.runningEntries[0] ?? null;
+  state.currentEntry = primary;
+  state.isRunning = !!primary;
+  state.elapsedTime = primary ? state.elapsedById[primary.id] ?? 0 : 0;
 };
 
 // Async thunks
@@ -33,10 +62,12 @@ export const startTimer = createAsyncThunk(
   ) => {
     try {
       const response = await timeEntriesAPI.startTimer(data);
-      return response;
+      return response as TimeEntry;
     } catch (error: any) {
       return rejectWithValue(
-        error.response?.data?.message || "Failed to start timer"
+        error.response?.data?.message ||
+          error.response?.data?.error ||
+          "Failed to start timer"
       );
     }
   }
@@ -47,76 +78,63 @@ export const stopTimer = createAsyncThunk(
   async (entryId: string, { rejectWithValue }) => {
     try {
       const response = await timeEntriesAPI.stopTimer(entryId);
-      return response;
+      return { entryId, response };
     } catch (error: any) {
       return rejectWithValue(
-        error.response?.data?.message || "Failed to stop timer"
+        error.response?.data?.message ||
+          error.response?.data?.error ||
+          "Failed to stop timer"
       );
     }
   }
 );
 
-export const fetchCurrentEntry = createAsyncThunk(
-  "timer/fetchCurrentEntry",
+export const fetchRunningEntries = createAsyncThunk(
+  "timer/fetchRunningEntries",
   async () => {
-    try {
-      const response = await timeEntriesAPI.getCurrentEntry();
-      // Handle API response format: {timeEntry: TimeEntry | null}
-      if (response && typeof response === "object" && "timeEntry" in response) {
-        return (response as any).timeEntry;
-      }
-      // Fallback for direct TimeEntry response (backward compatibility)
-      return response;
-    } catch (error: any) {
-      // Handle 404 error gracefully - no current entry is not an error condition
-      if (error.response?.status === 404) {
-        return null;
-      }
-      // Re-throw other errors
-      throw error;
-    }
+    const response = await timeEntriesAPI.getRunningEntries();
+    return response as TimeEntry[];
   },
   {
     condition: (_, { getState }) => {
       const { timer } = getState() as { timer: TimerState };
-      // Skip if already fetching — prevents duplicate concurrent requests
       return !timer.fetchingCurrentEntry;
     },
   }
 );
+
+// Legacy alias — older code dispatches fetchCurrentEntry on focus etc.
+export const fetchCurrentEntry = fetchRunningEntries;
 
 const timerSlice = createSlice({
   name: "timer",
   initialState,
   reducers: {
     tick: (state) => {
-      if (state.isRunning && state.currentEntry) {
-        // Ensure elapsedTime is a valid number before incrementing
-        if (!Number.isFinite(state.elapsedTime)) {
-          state.elapsedTime = 0;
-        }
-        state.elapsedTime += 1;
+      for (const entry of state.runningEntries) {
+        const prev = state.elapsedById[entry.id];
+        const next = Number.isFinite(prev) ? prev + 1 : 1;
+        state.elapsedById[entry.id] = next;
+      }
+      syncMirrors(state);
+      if (state.currentEntry) {
         state.currentEntry.duration = state.elapsedTime;
       }
     },
-    // Add a new action to sync timer with current time
     syncTimer: (state) => {
-      if (
-        state.isRunning &&
-        state.currentEntry &&
-        state.currentEntry.startTime
-      ) {
-        const startTime = new Date(state.currentEntry.startTime).getTime();
-        const now = new Date().getTime();
-        if (!isNaN(startTime) && !isNaN(now) && startTime <= now) {
-          state.elapsedTime = Math.floor((now - startTime) / 1000);
-          state.currentEntry.duration = state.elapsedTime;
-        }
+      for (const entry of state.runningEntries) {
+        state.elapsedById[entry.id] = elapsedFromStart(entry);
+      }
+      syncMirrors(state);
+      if (state.currentEntry) {
+        state.currentEntry.duration = state.elapsedTime;
       }
     },
     resetTimer: (state) => {
-      state.isRunning = false;
+      state.runningEntries = [];
+      state.elapsedById = {};
       state.currentEntry = null;
+      state.isRunning = false;
       state.elapsedTime = 0;
       state.error = null;
     },
@@ -126,95 +144,80 @@ const timerSlice = createSlice({
     // Socket event reducers
     timerStartedFromSocket: (state, action: PayloadAction<TimeEntry>) => {
       const entry = action.payload;
-      state.isRunning = true;
-      state.currentEntry = entry;
-      // Calculate elapsed time from start time
-      if (entry.startTime) {
-        const startTime = new Date(entry.startTime).getTime();
-        const now = new Date().getTime();
-        if (!isNaN(startTime) && !isNaN(now) && startTime <= now) {
-          state.elapsedTime = Math.floor((now - startTime) / 1000);
-        } else {
-          state.elapsedTime = entry.duration || 0;
-        }
-      } else {
-        state.elapsedTime = entry.duration || 0;
+      if (!state.runningEntries.find((e) => e.id === entry.id)) {
+        state.runningEntries.unshift(entry);
       }
+      state.elapsedById[entry.id] = elapsedFromStart(entry);
+      syncMirrors(state);
     },
-    timerStoppedFromSocket: (state) => {
-      state.isRunning = false;
-      state.currentEntry = null;
-      state.elapsedTime = 0;
+    timerStoppedFromSocket: (
+      state,
+      action: PayloadAction<{ id?: string } | undefined>
+    ) => {
+      const id = action.payload?.id;
+      if (id) {
+        state.runningEntries = state.runningEntries.filter((e) => e.id !== id);
+        delete state.elapsedById[id];
+      } else {
+        // No id — clear everything (legacy event shape).
+        state.runningEntries = [];
+        state.elapsedById = {};
+      }
+      syncMirrors(state);
     },
   },
   extraReducers: (builder) => {
     builder
-      // Start timer
       .addCase(startTimer.pending, (state) => {
         state.loading = true;
         state.error = null;
       })
       .addCase(startTimer.fulfilled, (state, action) => {
         state.loading = false;
-        state.isRunning = true;
-        state.currentEntry = action.payload;
-        state.elapsedTime = action.payload?.duration || 0;
+        const entry = action.payload;
+        if (entry && !state.runningEntries.find((e) => e.id === entry.id)) {
+          state.runningEntries.unshift(entry);
+        }
+        if (entry) {
+          state.elapsedById[entry.id] = entry.duration || 0;
+        }
+        syncMirrors(state);
       })
       .addCase(startTimer.rejected, (state, action) => {
         state.loading = false;
         state.error = (action.payload as string) || "Failed to start timer";
       })
-      // Stop timer
       .addCase(stopTimer.pending, (state) => {
         state.loading = true;
         state.error = null;
       })
-      .addCase(stopTimer.fulfilled, (state) => {
+      .addCase(stopTimer.fulfilled, (state, action) => {
         state.loading = false;
-        state.isRunning = false;
-        state.currentEntry = null;
-        state.elapsedTime = 0;
+        const id = action.payload.entryId;
+        state.runningEntries = state.runningEntries.filter((e) => e.id !== id);
+        delete state.elapsedById[id];
+        syncMirrors(state);
       })
       .addCase(stopTimer.rejected, (state, action) => {
         state.loading = false;
         state.error = (action.payload as string) || "Failed to stop timer";
       })
-      // Fetch current entry
-      .addCase(fetchCurrentEntry.pending, (state) => {
+      .addCase(fetchRunningEntries.pending, (state) => {
         state.fetchingCurrentEntry = true;
       })
-      .addCase(fetchCurrentEntry.rejected, (state) => {
+      .addCase(fetchRunningEntries.rejected, (state) => {
         state.fetchingCurrentEntry = false;
       })
-      .addCase(fetchCurrentEntry.fulfilled, (state, action) => {
+      .addCase(fetchRunningEntries.fulfilled, (state, action) => {
         state.fetchingCurrentEntry = false;
-        if (action.payload) {
-          state.isRunning = true;
-          state.currentEntry = action.payload;
-          // Calculate elapsed time from start time with proper validation
-          const startTimeValue = action.payload.startTime;
-
-          if (startTimeValue) {
-            const startTime = new Date(startTimeValue).getTime();
-            const now = new Date().getTime();
-
-            // Validate that both dates are valid numbers
-            if (!isNaN(startTime) && !isNaN(now) && startTime <= now) {
-              const calculatedElapsed = Math.floor((now - startTime) / 1000);
-              state.elapsedTime = calculatedElapsed;
-            } else {
-              // Fallback to duration from payload or 0
-              state.elapsedTime = action.payload.duration || 0;
-            }
-          } else {
-            // No start time, use duration from payload or 0
-            state.elapsedTime = action.payload.duration || 0;
-          }
-        } else {
-          state.isRunning = false;
-          state.currentEntry = null;
-          state.elapsedTime = 0;
+        const entries = Array.isArray(action.payload) ? action.payload : [];
+        state.runningEntries = entries;
+        const next: Record<string, number> = {};
+        for (const entry of entries) {
+          next[entry.id] = elapsedFromStart(entry);
         }
+        state.elapsedById = next;
+        syncMirrors(state);
       });
   },
 });
@@ -227,4 +230,11 @@ export const {
   timerStartedFromSocket,
   timerStoppedFromSocket,
 } = timerSlice.actions;
+
+// Selectors
+import type { RootState } from "../index";
+export const selectRunningEntries = (s: RootState) => s.timer.runningEntries;
+export const selectElapsedFor = (id: string) => (s: RootState) =>
+  s.timer.elapsedById[id] ?? 0;
+
 export default timerSlice.reducer;

--- a/packages/ui/src/store/slices/timerSlice.ts
+++ b/packages/ui/src/store/slices/timerSlice.ts
@@ -9,6 +9,9 @@ interface TimerState {
   runningEntries: TimeEntry[];
   // Per-entry live elapsed seconds, driven by tick/syncTimer.
   elapsedById: Record<string, number>;
+  // Per-entry stop-in-flight tracker so the stack can disable individual
+  // buttons without disabling all of them.
+  stoppingIds: Record<string, true>;
 
   // Backwards-compat mirrors of the most recent running entry. Old consumers
   // (Timer widget, header, electron display) keep reading these unchanged.
@@ -24,6 +27,7 @@ interface TimerState {
 const initialState: TimerState = {
   runningEntries: [],
   elapsedById: {},
+  stoppingIds: {},
   isRunning: false,
   currentEntry: null,
   elapsedTime: 0,
@@ -103,9 +107,6 @@ export const fetchRunningEntries = createAsyncThunk(
   }
 );
 
-// Legacy alias — older code dispatches fetchCurrentEntry on focus etc.
-export const fetchCurrentEntry = fetchRunningEntries;
-
 const timerSlice = createSlice({
   name: "timer",
   initialState,
@@ -116,27 +117,30 @@ const timerSlice = createSlice({
         const next = Number.isFinite(prev) ? prev + 1 : 1;
         state.elapsedById[entry.id] = next;
       }
+      // Source of truth for live elapsed is elapsedById — don't mutate the
+      // entry.duration field, since that's the stored value at last sync and
+      // mutating it makes "what's the entry's real duration" ambiguous.
       syncMirrors(state);
-      if (state.currentEntry) {
-        state.currentEntry.duration = state.elapsedTime;
-      }
     },
     syncTimer: (state) => {
       for (const entry of state.runningEntries) {
         state.elapsedById[entry.id] = elapsedFromStart(entry);
       }
       syncMirrors(state);
-      if (state.currentEntry) {
-        state.currentEntry.duration = state.elapsedTime;
-      }
     },
     resetTimer: (state) => {
       state.runningEntries = [];
       state.elapsedById = {};
+      state.stoppingIds = {};
       state.currentEntry = null;
       state.isRunning = false;
       state.elapsedTime = 0;
       state.error = null;
+    },
+    refetchRunningRequested: () => {
+      // Marker action — the dispatching code reacts by calling fetchRunningEntries.
+      // Keeping it as a no-op reducer here makes the intent explicit when it
+      // shows up in dev tools timelines.
     },
     clearError: (state) => {
       state.error = null;
@@ -158,12 +162,12 @@ const timerSlice = createSlice({
       if (id) {
         state.runningEntries = state.runningEntries.filter((e) => e.id !== id);
         delete state.elapsedById[id];
-      } else {
-        // No id — clear everything (legacy event shape).
-        state.runningEntries = [];
-        state.elapsedById = {};
+        delete state.stoppingIds[id];
+        syncMirrors(state);
       }
-      syncMirrors(state);
+      // No id: don't nuke state — the legacy event shape is ambiguous when
+      // multiple timers can run. Caller (useSocket) refetches /running to
+      // resync against the source of truth instead.
     },
   },
   extraReducers: (builder) => {
@@ -187,19 +191,22 @@ const timerSlice = createSlice({
         state.loading = false;
         state.error = (action.payload as string) || "Failed to start timer";
       })
-      .addCase(stopTimer.pending, (state) => {
+      .addCase(stopTimer.pending, (state, action) => {
         state.loading = true;
         state.error = null;
+        state.stoppingIds[action.meta.arg] = true;
       })
       .addCase(stopTimer.fulfilled, (state, action) => {
         state.loading = false;
         const id = action.payload.entryId;
         state.runningEntries = state.runningEntries.filter((e) => e.id !== id);
         delete state.elapsedById[id];
+        delete state.stoppingIds[id];
         syncMirrors(state);
       })
       .addCase(stopTimer.rejected, (state, action) => {
         state.loading = false;
+        delete state.stoppingIds[action.meta.arg];
         state.error = (action.payload as string) || "Failed to stop timer";
       })
       .addCase(fetchRunningEntries.pending, (state) => {
@@ -229,11 +236,13 @@ export const {
   clearError,
   timerStartedFromSocket,
   timerStoppedFromSocket,
+  refetchRunningRequested,
 } = timerSlice.actions;
 
 // Selectors
 import type { RootState } from "../index";
 export const selectRunningEntries = (s: RootState) => s.timer.runningEntries;
+export const selectStoppingIds = (s: RootState) => s.timer.stoppingIds;
 export const selectElapsedFor = (id: string) => (s: RootState) =>
   s.timer.elapsedById[id] ?? 0;
 


### PR DESCRIPTION
## Summary
- Removes the "one timer per user" guard so parallel AI coding sessions on different projects each get their own running timer
- Dashboard shows a stack of all running timers; each is independently stoppable
- Idle auto-stop skips AI-flagged entries so an unattended agent's timer doesn't die when the human's browser tab is idle

## What changed
- **API**: `POST /time-entries/start` no longer 400s when a timer is running. New `GET /time-entries/running` returns the array. `GET /time-entries/current` still returns the most recently started one (kept for backwards compat with mac/iOS apps).
- **UI Redux** (`timerSlice`): `runningEntries[]` is the new source of truth; the old `currentEntry`/`isRunning`/`elapsedTime` fields are derived mirrors of the most-recently-started entry so every existing consumer keeps working unchanged. New `elapsedById` map drives per-entry live timers in the stack.
- **Dashboard**: new `<RunningTimersStack />` shows all running timers as a stack of cards (project · task · AI badge · elapsed · stop). The `<Timer />` widget is reduced to a pure start form. Header `<TimerWidget />` shows "· N running" when more than one is active.
- **Idle monitor**: only auto-stops `isAiGenerated: false` entries. Agent timers run until the agent explicitly stops them.
- **MCP**: `current_timer` → `running_timers` (array). `stop_timer` without id auto-picks only when exactly one is running; otherwise returns the candidate list and asks the caller to specify.

## Test plan
- [ ] Two concurrent timers via different clients (JWT + API key with `X-Client: mcp`): both should appear in the Dashboard "Running now" stack, each with its own elapsed time and stop button. The AI one has the violet `AI · MCP` badge.
- [ ] Stop one of them — stack updates, the other keeps ticking.
- [ ] Header pill shows `· 2 running` when more than one is active, otherwise the project name.
- [ ] Idle: leave the browser idle past the configured timeout. Manual timer stops, AI timer keeps running. Toast says "Timer stopped" (singular) or "N timers stopped" depending on what was killed.
- [ ] Mac/iOS apps still work (they call `/current` — should return the most recently started one).
- [ ] Via MCP: `running_timers` returns the array. `stop_timer` with no args + 2 running → returns the candidate list. `stop_timer` with no args + 1 running → stops it.

## Migration / deploy
- No schema change.
- Pure code rollout — once deployed, multiple concurrent rows with `isRunning=true` start being possible. Mac/iOS apps reading `/current` continue to get a single entry (most recent), which matches their UI model.