### PR TITLE
Mobile: sidebar becomes a slide-in drawer below md

### DIFF
--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -4,13 +4,18 @@ import { Menu, Transition } from "@headlessui/react";
 import {
   ChevronDownIcon,
   ArrowRightOnRectangleIcon,
+  Bars3Icon,
 } from "@heroicons/react/24/outline";
 import { AppDispatch, RootState } from "../store";
 import { logout } from "../store/slices/authSlice";
 import TimerWidget from "./TimerWidget";
 import toast from "react-hot-toast";
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onOpenMenu?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onOpenMenu }) => {
   const dispatch = useDispatch<AppDispatch>();
   const { user } = useSelector((state: RootState) => state.auth);
 
@@ -26,13 +31,24 @@ const Header: React.FC = () => {
   };
 
   return (
-    <header className="bg-white border-b border-gray-200 px-6 py-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          <h2 className="text-lg font-semibold text-gray-900">Welcome back!</h2>
+    <header className="bg-white border-b border-gray-200 px-4 md:px-6 py-3 md:py-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 md:gap-4 min-w-0">
+          {/* Hamburger — phones only */}
+          <button
+            type="button"
+            onClick={onOpenMenu}
+            className="md:hidden -ml-1 p-2 text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
+            aria-label="Open navigation menu"
+          >
+            <Bars3Icon className="w-6 h-6" />
+          </button>
+          <h2 className="text-base md:text-lg font-semibold text-gray-900 truncate">
+            Welcome back!
+          </h2>
         </div>
 
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-2 md:gap-4 flex-shrink-0">
           {/* Timer Widget */}
           <TimerWidget />
 
@@ -61,14 +77,16 @@ const Header: React.FC = () => {
 
           {/* User menu */}
           <Menu as="div" className="relative">
-            <Menu.Button className="flex items-center space-x-2 text-sm font-medium text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-md px-2 py-1">
+            <Menu.Button className="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-md px-2 py-1">
               <div className="w-8 h-8 bg-primary-600 rounded-full flex items-center justify-center">
                 <span className="text-sm font-medium text-white">
                   {user?.name?.charAt(0).toUpperCase() || "U"}
                 </span>
               </div>
-              <span>{user?.name || "User"}</span>
-              <ChevronDownIcon className="w-4 h-4" />
+              <span className="hidden sm:inline truncate max-w-[8rem]">
+                {user?.name || "User"}
+              </span>
+              <ChevronDownIcon className="w-4 h-4 hidden sm:inline" />
             </Menu.Button>
 
             <Transition

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Outlet } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import Header from "./Header";
 import KeyboardShortcutsModal from "./KeyboardShortcutsModal";
@@ -32,14 +32,35 @@ const KeyboardShortcutsBehavior: React.FC = () => {
 };
 
 const Layout: React.FC = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const location = useLocation();
+
+  // Close the mobile drawer on any route change.
+  useEffect(() => {
+    setIsSidebarOpen(false);
+  }, [location.pathname]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsSidebarOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isSidebarOpen]);
+
   return (
     <div className="flex h-screen bg-gray-50">
       <BrowserEffects />
       <KeyboardShortcutsBehavior />
-      <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-50 p-6">
+      <Sidebar
+        isOpen={isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+      />
+      <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <Header onOpenMenu={() => setIsSidebarOpen(true)} />
+        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-50 p-4 md:p-6">
           <Outlet />
         </main>
       </div>

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -24,12 +24,34 @@ const isStaging = ((import.meta as any).env.VITE_API_URL || "").includes(
   "staging"
 );
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose }) => {
   const location = useLocation();
   const { user } = useSelector((state: RootState) => state.auth);
 
   return (
-    <div className="flex flex-col w-64 bg-white border-r border-gray-200">
+    <>
+      {/* Backdrop — phones only, only when the drawer is open */}
+      {isOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/50 z-40"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+      <aside
+        className={`
+          flex flex-col w-64 bg-white border-r border-gray-200
+          fixed inset-y-0 left-0 z-50 transform transition-transform duration-200
+          md:static md:translate-x-0
+          ${isOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
+        `}
+        aria-label="Primary navigation"
+      >
       {/* Logo */}
       <div className="flex items-center justify-center h-16 px-4 border-b border-gray-200">
         <h1 className="text-xl font-bold text-primary-600">TimeTrack</h1>
@@ -112,7 +134,8 @@ const Sidebar: React.FC = () => {
           for shortcuts
         </span>
       </div>
-    </div>
+      </aside>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- Sidebar was always-visible at \`w-64\`. On a 390px phone that left 134px for content — page was unusable.
- Below the md breakpoint (768px) the sidebar now slides in from the left as a drawer with a backdrop, hamburger button in the header to open it. Desktop unchanged.
- Tightened header / main padding under md so the page actually fits at phone widths.

## What changed
- \`Layout.tsx\` owns the open state. Closes the drawer on route change and on Escape.
- \`Sidebar.tsx\` accepts \`isOpen\` + \`onClose\`. \`fixed + transform\` under md; \`static + translate-x-0\` at md+. Backdrop closes on click.
- \`Header.tsx\` adds a hamburger visible only below md. User-menu name + chevron hide below sm to make room for the timer pill on tight widths; the avatar is still tappable.
- Main padding \`p-4 md:p-6\`. \`min-w-0\` on the flex column so its children can shrink instead of pushing horizontal overflow.

## Test plan
- [ ] Open the site on a phone (or set Chrome DevTools device to iPhone). The sidebar should be hidden, hamburger visible.
- [ ] Tap the hamburger → drawer slides in. Tap a link → drawer closes and the route changes.
- [ ] Tap the backdrop → drawer closes. Press Escape → drawer closes.
- [ ] Resize the window above 768px → drawer state goes away, sidebar is static again.
- [ ] On the Dashboard, RunningTimersStack cards wrap properly. Header timer pill + user avatar fit without overflow.

## Out of scope
Anything beyond the layout primitives (tables, modals, settings cards). Those use existing responsive grids and should already work — auditing them is a follow-up if they don't.