### PR TITLE
Fix Dashboard "This Week" using Sunday-start

### DIFF
--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -41,7 +41,7 @@ function getStartOfDayInTimezone(timezone: string): Date {
   return new Date(startOfDayLocal.getTime() + timezoneOffset);
 }
 
-// Helper function to get start of week in a specific timezone
+// Helper function to get start of week (Monday) in a specific timezone
 function getStartOfWeekInTimezone(timezone: string): Date {
   const now = new Date();
 
@@ -54,9 +54,13 @@ function getStartOfWeekInTimezone(timezone: string): Date {
   // Calculate the timezone offset
   const timezoneOffset = nowUTC.getTime() - nowInTimezone.getTime();
 
-  // Create start of week in the user's timezone (Sunday = 0)
+  // Days back to Monday: getDay() returns 0 for Sunday, 1 for Monday, ...
+  // On Sunday we go back 6 days; otherwise getDay() - 1.
+  const dayOfWeek = nowInTimezone.getDay();
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+
   const startOfWeekLocal = new Date(nowInTimezone);
-  startOfWeekLocal.setDate(nowInTimezone.getDate() - nowInTimezone.getDay());
+  startOfWeekLocal.setDate(nowInTimezone.getDate() - daysToMonday);
   startOfWeekLocal.setHours(0, 0, 0, 0);
 
   // Convert back to UTC for database queries

--- a/packages/shared/src/utils/timezone.ts
+++ b/packages/shared/src/utils/timezone.ts
@@ -32,7 +32,7 @@ export function getStartOfDayInTimezone(timezone: string): Date {
 /**
  * Get the start of week in a specific timezone and return as UTC
  * @param timezone - IANA timezone string (e.g., 'America/New_York')
- * @returns Date object representing start of week (Sunday) in the timezone, converted to UTC
+ * @returns Date object representing start of week (Monday) in the timezone, converted to UTC
  */
 export function getStartOfWeekInTimezone(timezone: string): Date {
   const now = new Date();
@@ -48,9 +48,13 @@ export function getStartOfWeekInTimezone(timezone: string): Date {
   // Calculate the timezone offset
   const timezoneOffset = nowUTC.getTime() - nowInTimezone.getTime();
 
-  // Create start of week in the user's timezone (Sunday = 0)
+  // Days back to Monday: getDay() returns 0 for Sunday, 1 for Monday, ...
+  // On Sunday we go back 6 days; otherwise getDay() - 1.
+  const dayOfWeek = nowInTimezone.getDay();
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+
   const startOfWeekLocal = new Date(nowInTimezone);
-  startOfWeekLocal.setDate(nowInTimezone.getDate() - nowInTimezone.getDay());
+  startOfWeekLocal.setDate(nowInTimezone.getDate() - daysToMonday);
   startOfWeekLocal.setHours(0, 0, 0, 0);
 
   // Convert back to UTC for database queries


### PR DESCRIPTION
## Summary
- API helper `getStartOfWeekInTimezone` used `setDate(... - getDay())`, putting the week boundary on Sunday. The Reports UI (`reportsSlice.ts`) already used Monday-start, so the Dashboard's "This Week" tile and the weekly chart disagreed for any day before Sunday.
- Switched the API helper (`packages/api/src/routes/users.ts`) and the duplicate in `packages/shared/src/utils/timezone.ts` to Monday-start using the same `dayOfWeek === 0 ? 6 : dayOfWeek - 1` formula proven in `reportsSlice.ts`.
- Affects `/users/stats` (`thisWeekTime`) and `/users/dashboard-earnings` (`thisWeek.earnings`/`thisWeek.duration`) — both Dashboard "This Week" cards.

## Test plan
- [ ] On a Monday (or after seeding entries spanning Sun→Mon), open the Dashboard and confirm "This Week" only includes Mon→now, not the prior Sunday
- [ ] Confirm the Reports page weekly chart sum matches the Dashboard "This Week" totals
- [ ] Spot-check across timezones (e.g., `America/New_York`, `Europe/London`, `Asia/Tokyo`) — pass `?timezone=...` to `/users/dashboard-earnings` and verify the Monday boundary is in the local zone
- [ ] `npm run type-check:all` clean