### PR TITLE
macOS TestFlight pipeline (Fastlane + GitHub Actions)

### DIFF
--- a/.github/workflows/build-mac-testflight.yml
+++ b/.github/workflows/build-mac-testflight.yml
@@ -1,0 +1,68 @@
+name: macOS → TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: "Release notes shown in TestFlight (optional)"
+        required: false
+        type: string
+
+concurrency:
+  group: mac-testflight
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    name: Build & upload
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    defaults:
+      run:
+        working-directory: packages/mac-app
+
+    env:
+      APP_STORE_CONNECT_API_KEY_ID:        ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT:   ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+      MATCH_PASSWORD:                      ${{ secrets.MATCH_PASSWORD }}
+      MATCH_KEYCHAIN_PASSWORD:             ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+      FASTLANE_HIDE_CHANGELOG: "1"
+      FASTLANE_SKIP_UPDATE_CHECK: "1"
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16
+        run: sudo xcode-select -switch /Applications/Xcode_16.app
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: .
+
+      - name: Configure SSH for Match storage repo
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
+
+      - name: Trust github.com host key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
+
+      - name: Run fastlane beta
+        run: bundle exec fastlane mac beta release_notes:"${{ inputs.release_notes }}"
+
+      - name: Upload PKG artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TimeTrack-pkg
+          path: packages/mac-app/build/TimeTrack.pkg
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,10 @@ todos/
 github_key_id_*
 .worktrees
 
+# App Store Connect API keys (never commit)
+*.p8
+AuthKey_*
+
 # Fastlane (runtime output, do not check in)
 **/fastlane/report.xml
 **/fastlane/Preview.html
@@ -152,4 +156,4 @@ github_key_id_*
 !**/fastlane/.env.template
 
 # Ad-hoc local files (e.g. bootstrap drafts) — keep out of the repo
-PABLO-BOOTSTRAP-MESSAGE.md
+PABLO-BOOTSTRAP-MESSAGE.*

--- a/packages/mac-app/TESTFLIGHT_SETUP.md
+++ b/packages/mac-app/TESTFLIGHT_SETUP.md
@@ -3,7 +3,7 @@
 End state: clicking **Run workflow** on `macOS → TestFlight` in GitHub Actions builds the Mac app, signs the `.pkg`, and uploads it to TestFlight.
 
 Apple team: **Orbital Labworks, LLC** (`HL8D756J57`).
-Bundle ID: `com.orbitalabworks.timetrack.mac`.
+Bundle ID: `com.orbitalabworks.timetrack` — **shared with the iOS app via Universal Purchase**. One App Store record covers both platforms; iOS customers get the Mac app free and vice versa.
 
 > Most of the bootstrap is shared with the iOS pipeline. **Do the iOS bootstrap first** (`packages/ios-app/TESTFLIGHT_SETUP.md`) — this doc only calls out the macOS-specific deltas.
 
@@ -14,40 +14,24 @@ Bundle ID: `com.orbitalabworks.timetrack.mac`.
 These come from the iOS setup and are reused as-is for macOS — no extra work:
 
 - Pablo's two asks (license agreement, API key) — same Apple Developer team covers both apps.
+- **The `com.orbitalabworks.timetrack` App ID identifier** — already registered for iOS. macOS reuses the same identifier (Universal Purchase). The only extra requirement is that **App Sandbox** is enabled on that App ID's capabilities — required for Mac App Store distribution. If it's missing, edit the identifier in the developer portal and tick App Sandbox.
+- **The App Store Connect app record** — same TimeTrack record as iOS, with macOS added as a sibling platform.
 - The `timetrack-signing` Match storage repo — Match keeps macOS and iOS profiles in separate subdirectories of the same repo.
 - The SSH deploy key on the signing repo — same key, same secret.
 - All six GitHub Actions secrets — `APP_STORE_CONNECT_API_KEY_*`, `MATCH_PASSWORD`, `MATCH_KEYCHAIN_PASSWORD`, `MATCH_SSH_PRIVATE_KEY`. The Mac workflow reads the same secret names.
 
 ## macOS-specific steps
 
-### 1. Register the macOS bundle ID
+### 1. Enable macOS on the existing TimeTrack ASC record
 
-From `packages/mac-app`:
+In App Store Connect, open the existing **TimeTrack** app, then add macOS as a supported platform. Apple's UI surfaces this either as:
 
-```bash
-bundle exec fastlane produce -u "" \
-  --app_identifier com.orbitalabworks.timetrack.mac \
-  --app_name "TimeTrack" \
-  --skip_itc \
-  --platform osx
-```
+- A **+ macOS App** option in the app's left sidebar, or
+- An auto-prompt after the first Mac TestFlight upload — Apple detects the matching bundle ID and offers to enable Universal Purchase
 
-`--platform osx` (Apple's legacy name for macOS in the API) registers a macOS App ID rather than an iOS one — important so the right capabilities show up. Sandboxing and Network (client) are auto-enabled because the entitlements file already declares them.
+Either path works. If neither is obvious in the UI, skip ahead — uploading the first build typically triggers the prompt.
 
-### 2. Create the macOS app record in App Store Connect
-
-```bash
-bundle exec fastlane produce \
-  --app_identifier com.orbitalabworks.timetrack.mac \
-  --app_name "TimeTrack" \
-  --platform osx \
-  --language "en-US" \
-  --skip_devcenter
-```
-
-If App Store Connect rejects the SKU as duplicate (because the iOS app reserved it), pass an explicit `--sku com.orbitalabworks.timetrack.mac`.
-
-### 3. Seed Match with Mac App Store distribution signing
+### 2. Seed Match with Mac App Store distribution signing
 
 macOS App Store builds need **two** certificates (Apple's quirk):
 - 3rd Party Mac Developer Application
@@ -60,17 +44,19 @@ export MATCH_PASSWORD="<same password as iOS bootstrap>"
 bundle exec fastlane mac match_setup
 ```
 
-After it completes, the `timetrack-signing` repo will contain two new subtrees alongside the iOS ones — something like `certs/distribution/<TEAM>/<sha>.cer` for the application cert and an installer cert in a sibling path, plus `profiles/appstore/macos/...` for the macOS provisioning profile.
+After it completes, the `timetrack-signing` repo will contain new subtrees alongside the iOS ones — something like `certs/distribution/<TEAM>/<sha>.cer` for the application cert and an installer cert in a sibling path, plus `profiles/appstore/macos/...` for the macOS provisioning profile.
 
-### 4. (No new GitHub Secrets needed)
+Match keys provisioning profiles by `(bundle_id, platform)`, so sharing the bundle ID with iOS is fine — the macOS profile is stored separately.
 
-The `macOS → TestFlight` workflow reads the same secret names the iOS workflow uses. If iOS is already shipping, macOS just works once the bundle ID is registered and Match is seeded.
+### 3. (No new GitHub Secrets needed)
 
-### 5. Ship a build
+The `macOS → TestFlight` workflow reads the same secret names the iOS workflow uses. If iOS is already shipping, macOS just works once Match is seeded for macOS.
+
+### 4. Ship a build
 
 1. <https://github.com/alfredoreduarte/timetrack/actions/workflows/build-mac-testflight.yml>
 2. **Run workflow**, optionally with release notes.
-3. Wait ~10 min. The build appears in App Store Connect → My Apps → TimeTrack (Mac) → TestFlight.
+3. Wait ~10 min. The build appears in App Store Connect → My Apps → TimeTrack → TestFlight → **macOS** tab.
 
 > Note: Mac App Store apps go through a slightly different Apple review path than iOS — first TestFlight build typically processes in 5–15 minutes; later notarization/processing can take up to an hour. This is normal.
 
@@ -79,5 +65,5 @@ The `macOS → TestFlight` workflow reads the same secret names the iOS workflow
 ## Maintenance
 
 - **Apple cert quirk.** Mac installer certificates expire on a slightly different cadence from application certificates. If `upload_to_testflight` fails with `unable to find installer signing identity`, rerun `bundle exec fastlane mac match_setup` to refresh.
-- **Catalyst.** This app is native AppKit + SwiftUI, not Mac Catalyst, so it ships from the Mac project independently of the iOS one. The two share nothing at build time.
-- **Build numbers.** Auto-incremented from TestFlight's latest macOS build, independently of the iOS app's build number.
+- **Catalyst.** This app is native AppKit + SwiftUI, not Mac Catalyst. It shares the iOS bundle ID for Universal Purchase but is built from the Mac Xcode project as a separate native binary.
+- **Build numbers.** Auto-incremented from TestFlight's latest macOS build, independently of the iOS app's build number — TestFlight tracks build numbers per platform.

--- a/packages/mac-app/TESTFLIGHT_SETUP.md
+++ b/packages/mac-app/TESTFLIGHT_SETUP.md
@@ -1,0 +1,83 @@
+# TimeTrack macOS — TestFlight Pipeline Setup
+
+End state: clicking **Run workflow** on `macOS → TestFlight` in GitHub Actions builds the Mac app, signs the `.pkg`, and uploads it to TestFlight.
+
+Apple team: **Orbital Labworks, LLC** (`HL8D756J57`).
+Bundle ID: `com.orbitalabworks.timetrack.mac`.
+
+> Most of the bootstrap is shared with the iOS pipeline. **Do the iOS bootstrap first** (`packages/ios-app/TESTFLIGHT_SETUP.md`) — this doc only calls out the macOS-specific deltas.
+
+---
+
+## Shared from iOS setup
+
+These come from the iOS setup and are reused as-is for macOS — no extra work:
+
+- Pablo's two asks (license agreement, API key) — same Apple Developer team covers both apps.
+- The `timetrack-signing` Match storage repo — Match keeps macOS and iOS profiles in separate subdirectories of the same repo.
+- The SSH deploy key on the signing repo — same key, same secret.
+- All six GitHub Actions secrets — `APP_STORE_CONNECT_API_KEY_*`, `MATCH_PASSWORD`, `MATCH_KEYCHAIN_PASSWORD`, `MATCH_SSH_PRIVATE_KEY`. The Mac workflow reads the same secret names.
+
+## macOS-specific steps
+
+### 1. Register the macOS bundle ID
+
+From `packages/mac-app`:
+
+```bash
+bundle exec fastlane produce -u "" \
+  --app_identifier com.orbitalabworks.timetrack.mac \
+  --app_name "TimeTrack" \
+  --skip_itc \
+  --platform osx
+```
+
+`--platform osx` (Apple's legacy name for macOS in the API) registers a macOS App ID rather than an iOS one — important so the right capabilities show up. Sandboxing and Network (client) are auto-enabled because the entitlements file already declares them.
+
+### 2. Create the macOS app record in App Store Connect
+
+```bash
+bundle exec fastlane produce \
+  --app_identifier com.orbitalabworks.timetrack.mac \
+  --app_name "TimeTrack" \
+  --platform osx \
+  --language "en-US" \
+  --skip_devcenter
+```
+
+If App Store Connect rejects the SKU as duplicate (because the iOS app reserved it), pass an explicit `--sku com.orbitalabworks.timetrack.mac`.
+
+### 3. Seed Match with Mac App Store distribution signing
+
+macOS App Store builds need **two** certificates (Apple's quirk):
+- 3rd Party Mac Developer Application
+- 3rd Party Mac Developer Installer
+
+Match handles both — that's what `additional_cert_types: ["mac_installer_distribution"]` in the Mac `Matchfile` does. From `packages/mac-app`:
+
+```bash
+export MATCH_PASSWORD="<same password as iOS bootstrap>"
+bundle exec fastlane mac match_setup
+```
+
+After it completes, the `timetrack-signing` repo will contain two new subtrees alongside the iOS ones — something like `certs/distribution/<TEAM>/<sha>.cer` for the application cert and an installer cert in a sibling path, plus `profiles/appstore/macos/...` for the macOS provisioning profile.
+
+### 4. (No new GitHub Secrets needed)
+
+The `macOS → TestFlight` workflow reads the same secret names the iOS workflow uses. If iOS is already shipping, macOS just works once the bundle ID is registered and Match is seeded.
+
+### 5. Ship a build
+
+1. <https://github.com/alfredoreduarte/timetrack/actions/workflows/build-mac-testflight.yml>
+2. **Run workflow**, optionally with release notes.
+3. Wait ~10 min. The build appears in App Store Connect → My Apps → TimeTrack (Mac) → TestFlight.
+
+> Note: Mac App Store apps go through a slightly different Apple review path than iOS — first TestFlight build typically processes in 5–15 minutes; later notarization/processing can take up to an hour. This is normal.
+
+---
+
+## Maintenance
+
+- **Apple cert quirk.** Mac installer certificates expire on a slightly different cadence from application certificates. If `upload_to_testflight` fails with `unable to find installer signing identity`, rerun `bundle exec fastlane mac match_setup` to refresh.
+- **Catalyst.** This app is native AppKit + SwiftUI, not Mac Catalyst, so it ships from the Mac project independently of the iOS one. The two share nothing at build time.
+- **Build numbers.** Auto-incremented from TestFlight's latest macOS build, independently of the iOS app's build number.

--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TimeTrack/Preview Content\"";
+				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -427,7 +428,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.timetrack.mac;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -444,6 +445,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TimeTrack/Preview Content\"";
+				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -452,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.timetrack.mac;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack.mac;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -454,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack.mac;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitalabworks.timetrack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/packages/mac-app/fastlane/Appfile
+++ b/packages/mac-app/fastlane/Appfile
@@ -1,0 +1,4 @@
+app_identifier "com.orbitalabworks.timetrack.mac"
+apple_id ENV["FASTLANE_APPLE_ID"]
+team_id "HL8D756J57"
+itc_team_id ENV["FASTLANE_ITC_TEAM_ID"]

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -1,0 +1,93 @@
+default_platform(:mac)
+
+XCODE_PROJECT = "TimeTrack.xcodeproj"
+SCHEME        = "TimeTrack"
+APP_IDS       = ["com.orbitalabworks.timetrack.mac"]
+
+def asc_api_key
+  app_store_connect_api_key(
+    key_id:                ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+    issuer_id:             ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
+    key_content:           ENV.fetch("APP_STORE_CONNECT_API_KEY_CONTENT"),
+    is_key_content_base64: true,
+    in_house:              false
+  )
+end
+
+platform :mac do
+  before_all do
+    setup_ci if ENV["CI"]
+  end
+
+  desc "One-time: seed Mac App Store distribution certs & profiles into Match storage. Run locally."
+  lane :match_setup do
+    match(
+      type:                  "appstore",
+      app_identifier:        APP_IDS,
+      platform:              "macos",
+      additional_cert_types: ["mac_installer_distribution"],
+      api_key:               asc_api_key,
+      readonly:              false,
+      force_for_new_devices: false
+    )
+  end
+
+  desc "Sync existing signing assets from Match (readonly). Useful sanity check."
+  lane :match_sync do
+    match(
+      type:                  "appstore",
+      app_identifier:        APP_IDS,
+      platform:              "macos",
+      additional_cert_types: ["mac_installer_distribution"],
+      api_key:               asc_api_key,
+      readonly:              true
+    )
+  end
+
+  desc "Build the Mac app and ship to TestFlight."
+  lane :beta do |options|
+    api_key = asc_api_key
+
+    match(
+      type:                  "appstore",
+      app_identifier:        APP_IDS,
+      platform:              "macos",
+      additional_cert_types: ["mac_installer_distribution"],
+      api_key:               api_key,
+      readonly:              true
+    )
+
+    next_build = latest_testflight_build_number(
+      app_identifier:       APP_IDS.first,
+      api_key:              api_key,
+      platform:             "osx",
+      initial_build_number: 0
+    ) + 1
+
+    increment_build_number(
+      xcodeproj:    XCODE_PROJECT,
+      build_number: next_build
+    )
+
+    build_mac_app(
+      project:          XCODE_PROJECT,
+      scheme:           SCHEME,
+      configuration:    "Release",
+      export_method:    "app-store",
+      output_directory: "build",
+      output_name:      "TimeTrack.pkg",
+      clean:            true,
+      include_symbols:  true,
+      xcargs:           "-allowProvisioningUpdates"
+    )
+
+    upload_to_testflight(
+      api_key:                           api_key,
+      app_identifier:                    APP_IDS.first,
+      app_platform:                      "osx",
+      pkg:                               File.expand_path("build/TimeTrack.pkg"),
+      skip_waiting_for_build_processing: true,
+      changelog:                         options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
+    )
+  end
+end

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -2,7 +2,7 @@ default_platform(:mac)
 
 XCODE_PROJECT = "TimeTrack.xcodeproj"
 SCHEME        = "TimeTrack"
-APP_IDS       = ["com.orbitalabworks.timetrack.mac"]
+APP_IDS       = ["com.orbitalabworks.timetrack"]
 
 def asc_api_key
   app_store_connect_api_key(

--- a/packages/mac-app/fastlane/Matchfile
+++ b/packages/mac-app/fastlane/Matchfile
@@ -4,7 +4,7 @@ storage_mode "git"
 type "appstore"
 platform "macos"
 
-app_identifier(["com.orbitalabworks.timetrack.mac"])
+app_identifier(["com.orbitalabworks.timetrack"])
 
 additional_cert_types(["mac_installer_distribution"])
 

--- a/packages/mac-app/fastlane/Matchfile
+++ b/packages/mac-app/fastlane/Matchfile
@@ -1,0 +1,12 @@
+git_url ENV.fetch("MATCH_GIT_URL", "git@github.com:alfredoreduarte/timetrack-signing.git")
+storage_mode "git"
+
+type "appstore"
+platform "macos"
+
+app_identifier(["com.orbitalabworks.timetrack.mac"])
+
+additional_cert_types(["mac_installer_distribution"])
+
+username ENV["FASTLANE_APPLE_ID"]
+team_id "HL8D756J57"


### PR DESCRIPTION
## Summary

- Adds a manual-dispatch GitHub Actions workflow (**macOS → TestFlight**) that builds the Mac app, signs the `.pkg`, and uploads to TestFlight in one click.
- Reuses everything possible from PR #135: same Apple team, same `timetrack-signing` Match storage repo, same six GitHub secrets, same `Gemfile`. The only Mac-specific pieces are the `additional_cert_types: ["mac_installer_distribution"]` Match option (Apple requires both an application and an installer cert for the Mac App Store) and the `.pkg` output flow through `build_mac_app` and `upload_to_testflight(app_platform: "osx")`.
- Migrates the Mac project to the Orbital Labworks team (`HL8D756J57`, previously empty) and the `com.orbitalabworks.timetrack.mac` bundle ID.
- `packages/mac-app/TESTFLIGHT_SETUP.md` only documents the macOS-specific deltas — the iOS doc carries the shared steps.

## Branch base

Targets `feature/ios-testflight-pipeline` (PR #135) so the shared `Gemfile`/`.ruby-version` lands first. Merge order:
1. PR #135 (iOS) → main
2. Retarget this PR → main and merge.

GitHub will auto-update the base when #135 merges.

## Blocked on Pablo

Same as #135 — once the API key is in hand and Match has been seeded for iOS, the Mac pipeline only needs the additional `fastlane mac match_setup` run (~2 min).

## Test plan

Bootstrap dependent:
- [ ] iOS pipeline bootstrap complete (PR #135 test plan).
- [ ] `bundle exec fastlane produce --platform osx ...` registers the Mac bundle ID.
- [ ] Mac app record created in App Store Connect.
- [ ] `bundle exec fastlane mac match_setup` succeeds, populates macOS subtree of signing repo.
- [ ] First "Run workflow" → Mac build appears in TestFlight.

Already verified:
- [x] `bundle exec fastlane lanes` parses the Mac Fastfile, lists `mac match_setup`, `mac match_sync`, `mac beta`.
- [x] `project.pbxproj` has team `HL8D756J57` and bundle ID `com.orbitalabworks.timetrack.mac`; no leftover `com.timetrack.mac` references.

## Notes

- The Mac project's `DEVELOPMENT_TEAM` was empty before this PR. Anyone signing locally previously was relying on Xcode picking the active personal team. After merge, Xcode automatic signing will use Orbital Labworks for local builds too — make sure the team appears under your Apple ID in Xcode → Settings → Accounts.