### PR TITLE
Fix Mac TestFlight: switch to Manual signing in CI

### DIFF
--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -69,6 +69,16 @@ platform :mac do
       build_number: next_build
     )
 
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path:                  XCODE_PROJECT,
+      code_sign_identity:    "Apple Distribution",
+      profile_name:          "match AppStore com.orbitalabworks.timetrack macos",
+      bundle_identifier:     APP_IDS.first,
+      team_id:               "HL8D756J57",
+      targets:               [SCHEME]
+    )
+
     build_mac_app(
       project:          XCODE_PROJECT,
       scheme:           SCHEME,
@@ -77,8 +87,7 @@ platform :mac do
       output_directory: "build",
       output_name:      "TimeTrack.pkg",
       clean:            true,
-      include_symbols:  true,
-      xcargs:           "-allowProvisioningUpdates"
+      include_symbols:  true
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## Summary

First Mac TestFlight build failed at `build_mac_app` with:

```
error: No signing certificate "Mac Development" found:
No "Mac Development" signing certificate matching team ID "HL8D756J57"
with a private key was found.
```

Root cause: the Mac project ships with `CODE_SIGN_STYLE = Automatic`. On a clean macOS-15 runner there's no Apple ID logged into Xcode, so xcodebuild can't auto-fetch a development cert during archive.

## Fix

Add `update_code_signing_settings` before `build_mac_app` to flip the project to Manual signing in CI, pointing at the Match-installed AppStore profile. The pbxproj stays on Automatic on disk so local Xcode builds keep working.

## Test plan

- [ ] Re-trigger `macOS → TestFlight` workflow; archive succeeds and the .pkg uploads to TestFlight.
- [ ] Local Xcode build of `packages/mac-app/TimeTrack.xcodeproj` still works (Automatic signing locally unchanged).