### PR TITLE
Fix Mac TestFlight: correct .pkg path and filename for upload

### DIFF
--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -85,7 +85,7 @@ platform :mac do
       configuration:    "Release",
       export_method:    "app-store",
       output_directory: "build",
-      output_name:      "TimeTrack.pkg",
+      output_name:      "TimeTrack",
       clean:            true,
       include_symbols:  true
     )
@@ -94,7 +94,7 @@ platform :mac do
       api_key:                           api_key,
       app_identifier:                    APP_IDS.first,
       app_platform:                      "osx",
-      pkg:                               File.expand_path("build/TimeTrack.pkg"),
+      pkg:                               lane_context[SharedValues::PKG_OUTPUT_PATH],
       skip_waiting_for_build_processing: true,
       changelog:                         options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
     )

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -69,6 +69,16 @@ platform :mac do
       build_number: next_build
     )
 
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path:                  XCODE_PROJECT,
+      code_sign_identity:    "Apple Distribution",
+      profile_name:          "match AppStore com.orbitalabworks.timetrack macos",
+      bundle_identifier:     APP_IDS.first,
+      team_id:               "HL8D756J57",
+      targets:               [SCHEME]
+    )
+
     build_mac_app(
       project:          XCODE_PROJECT,
       scheme:           SCHEME,
@@ -77,8 +87,7 @@ platform :mac do
       output_directory: "build",
       output_name:      "TimeTrack.pkg",
       clean:            true,
-      include_symbols:  true,
-      xcargs:           "-allowProvisioningUpdates"
+      include_symbols:  true
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## Summary

Second Mac TestFlight retry passed the signing fix from #138 but failed at the upload step with:

\`Could not find pkg file at '/.../packages/mac-app/fastlane/build/TimeTrack.pkg'\`

Two bugs in the Fastfile, both visible in the lane context dump:

1. \`output_name: "TimeTrack.pkg"\` → gym appends \`.pkg\` itself, so the actual file landed at \`TimeTrack.pkg.pkg\`.
2. \`File.expand_path("build/TimeTrack.pkg")\` resolved relative to fastlane's cwd (\`packages/mac-app/fastlane\`) rather than to the project root (\`packages/mac-app\`) where \`build/\` actually lives.

## Fix

- Drop the \`.pkg\` from \`output_name\` (one suffix instead of two).
- Use \`lane_context[SharedValues::PKG_OUTPUT_PATH]\` for the upload — that's the canonical path gym sets, so no path-resolution guessing.

## Test plan

- [ ] Re-trigger \`macOS → TestFlight\`; the build + sign succeed (already confirmed by PR #138) and the .pkg uploads to TestFlight this time.