### PR TITLE
Fix TestFlight: materialize ASC API key, iOS manual signing

### DIFF
--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -55,6 +55,14 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
 
+      - name: Materialize App Store Connect API key
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          printf '%s' "${APP_STORE_CONNECT_API_KEY_CONTENT}" | base64 -d > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Run fastlane beta
         run: bundle exec fastlane ios beta release_notes:"${{ inputs.release_notes }}"
 

--- a/.github/workflows/build-mac-testflight.yml
+++ b/.github/workflows/build-mac-testflight.yml
@@ -55,6 +55,14 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
 
+      - name: Materialize App Store Connect API key
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          printf '%s' "${APP_STORE_CONNECT_API_KEY_CONTENT}" | base64 -d > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Run fastlane beta
         run: bundle exec fastlane mac beta release_notes:"${{ inputs.release_notes }}"
 

--- a/packages/ios-app/fastlane/Fastfile
+++ b/packages/ios-app/fastlane/Fastfile
@@ -9,13 +9,25 @@ APP_IDS = [
 ]
 
 def asc_api_key
-  app_store_connect_api_key(
-    key_id:              ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
-    issuer_id:           ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
-    key_content:         ENV.fetch("APP_STORE_CONNECT_API_KEY_CONTENT"),
-    is_key_content_base64: true,
-    in_house:            false
-  )
+  # Prefer key_filepath when the workflow materializes the .p8 to disk.
+  # altool (used by upload_to_testflight) is finicky about in-memory keys
+  # and reliably reads from ~/.appstoreconnect/private_keys/AuthKey_<id>.p8.
+  if ENV["ASC_API_KEY_PATH"]
+    app_store_connect_api_key(
+      key_id:       ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id:    ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
+      key_filepath: ENV.fetch("ASC_API_KEY_PATH"),
+      in_house:     false
+    )
+  else
+    app_store_connect_api_key(
+      key_id:                ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id:             ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
+      key_content:           ENV.fetch("APP_STORE_CONNECT_API_KEY_CONTENT"),
+      is_key_content_base64: true,
+      in_house:              false
+    )
+  end
 end
 
 platform :ios do
@@ -66,6 +78,22 @@ platform :ios do
       build_number: next_build
     )
 
+    {
+      "Timetrack"                      => "com.orbitalabworks.timetrack",
+      "Timetrack Watch Watch App"      => "com.orbitalabworks.timetrack.watchkitapp",
+      "TimetrackLiveActivityExtension" => "com.orbitalabworks.timetrack.liveactivity"
+    }.each do |target, bundle_id|
+      update_code_signing_settings(
+        use_automatic_signing: false,
+        path:                  XCODE_PROJECT,
+        code_sign_identity:    "Apple Distribution",
+        profile_name:          "match AppStore #{bundle_id}",
+        bundle_identifier:     bundle_id,
+        team_id:               "HL8D756J57",
+        targets:               [target]
+      )
+    end
+
     build_app(
       project:          XCODE_PROJECT,
       scheme:           SCHEME,
@@ -75,8 +103,7 @@ platform :ios do
       output_name:      "Timetrack.ipa",
       clean:            true,
       include_symbols:  true,
-      include_bitcode:  false,
-      xcargs:           "-allowProvisioningUpdates"
+      include_bitcode:  false
     )
 
     upload_to_testflight(

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -5,13 +5,25 @@ SCHEME        = "TimeTrack"
 APP_IDS       = ["com.orbitalabworks.timetrack"]
 
 def asc_api_key
-  app_store_connect_api_key(
-    key_id:                ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
-    issuer_id:             ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
-    key_content:           ENV.fetch("APP_STORE_CONNECT_API_KEY_CONTENT"),
-    is_key_content_base64: true,
-    in_house:              false
-  )
+  # Prefer key_filepath when the workflow materializes the .p8 to disk.
+  # altool (used by upload_to_testflight) is finicky about in-memory keys
+  # and reliably reads from ~/.appstoreconnect/private_keys/AuthKey_<id>.p8.
+  if ENV["ASC_API_KEY_PATH"]
+    app_store_connect_api_key(
+      key_id:       ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id:    ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
+      key_filepath: ENV.fetch("ASC_API_KEY_PATH"),
+      in_house:     false
+    )
+  else
+    app_store_connect_api_key(
+      key_id:                ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id:             ENV.fetch("APP_STORE_CONNECT_API_KEY_ISSUER_ID"),
+      key_content:           ENV.fetch("APP_STORE_CONNECT_API_KEY_CONTENT"),
+      is_key_content_base64: true,
+      in_house:              false
+    )
+  end
 end
 
 platform :mac do


### PR DESCRIPTION
## Summary

Mac retry #3 (post #139) got past build + sign, but `upload_to_testflight` failed at altool with:

> Failed to authenticate with errors:
> Failed to generate JWT token: ... "The file couldn't be opened because it isn't in the correct format."

altool can't reliably parse the .p8 fastlane writes when it gets the key via `key_content + is_key_content_base64`. The fix is to drop the .p8 onto disk at altool's conventional path before fastlane runs.

## Fix

Workflow (iOS + Mac):
- New step "Materialize App Store Connect API key" — base64-decodes the secret into `~/.appstoreconnect/private_keys/AuthKey_<id>.p8`, chmod 600, exports `ASC_API_KEY_PATH`.

Fastfile (iOS + Mac):
- `asc_api_key` now uses `key_filepath` when `ASC_API_KEY_PATH` is set, falling back to the old in-memory path for local runs (where the workflow step doesn't fire).

Also bundled, since iOS has the same `CODE_SIGN_STYLE = Automatic` problem as Mac:
- iOS Fastfile now loops over its three shipping targets (Timetrack, Watch app, LiveActivity extension) and calls `update_code_signing_settings` for each, pointing at their respective Match-installed AppStore profiles — preempts the same "No Mac Development cert" failure on iOS.

## Test plan

- [ ] Re-trigger \`macOS → TestFlight\`; archive + sign + upload all succeed; build appears in App Store Connect TestFlight.
- [ ] Re-trigger \`iOS → TestFlight\` (after Pablo finishes registering the watchkitapp + liveactivity bundle IDs and the shared app group, and after I seed Match for iOS); same flow.