### PR TITLE
Drop changelog from upload_to_testflight (fixes 60-min wait)

### DIFF
--- a/packages/ios-app/fastlane/Fastfile
+++ b/packages/ios-app/fastlane/Fastfile
@@ -106,11 +106,15 @@ platform :ios do
       include_bitcode:  false
     )
 
+    # Note: passing changelog forces fastlane to wait for the build to
+    # appear in ASC's build list (overrides
+    # skip_waiting_for_build_processing). For first uploads of a new app
+    # that wait is 10-30min and trips the job cap. Skip the changelog
+    # here — set it from the ASC UI, or via a future set_changelog lane.
     upload_to_testflight(
       api_key:                          api_key,
       app_identifier:                   APP_IDS.first,
-      skip_waiting_for_build_processing: true,
-      changelog:                        options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
+      skip_waiting_for_build_processing: true
     )
   end
 end

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -102,13 +102,17 @@ platform :mac do
       include_symbols:  true
     )
 
+    # Note: passing changelog forces fastlane to wait for the build to
+    # appear in App Store Connect's build list (overrides
+    # skip_waiting_for_build_processing). For first uploads of a new app
+    # that wait is 10-30min and trips the job cap. Skip the changelog
+    # here — set it from the ASC UI, or via a future set_changelog lane.
     upload_to_testflight(
       api_key:                           api_key,
       app_identifier:                    APP_IDS.first,
       app_platform:                      "osx",
       pkg:                               lane_context[SharedValues::PKG_OUTPUT_PATH],
-      skip_waiting_for_build_processing: true,
-      changelog:                         options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
+      skip_waiting_for_build_processing: true
     )
   end
 end


### PR DESCRIPTION
## Summary

The first Mac TestFlight upload (PR #140's flow) **succeeded** at the altool layer at 23:45:56:

\`\`\`
Successfully uploaded package to App Store Connect.
It might take a few minutes until it's visible online.
\`\`\`

But the job got killed by the 60-min \`timeout-minutes\` cap because fastlane spent the next 18+ min polling for the build to appear in ASC's build list. Root cause: passing \`changelog:\` to \`upload_to_testflight\` forces fastlane to wait — it has to find the build to attach the changelog. That wait overrides \`skip_waiting_for_build_processing\`.

For first builds of a brand-new app, Apple takes 10-30 min to make the build visible.

## Fix

Drop \`changelog:\` from \`upload_to_testflight\` in both iOS and Mac Fastfiles. With \`skip_waiting_for_build_processing: true\` now actually effective, fastlane returns immediately after altool's upload. Release notes get set from the ASC UI; if we ever want automated changelog attachment, do it as a separate \`set_changelog\` lane after Apple finishes processing.

## Test plan

- [ ] Trigger a fresh Mac TestFlight build; job completes in ~3-5 min instead of hitting the cap.
- [ ] Verify the .pkg appears in ASC TestFlight (it should already, from the previous successful upload).