### PR TITLE
Skip post-upload wait by dropping changelog from upload_to_testflight

### DIFF
--- a/packages/ios-app/fastlane/Fastfile
+++ b/packages/ios-app/fastlane/Fastfile
@@ -106,11 +106,15 @@ platform :ios do
       include_bitcode:  false
     )
 
+    # Note: passing changelog forces fastlane to wait for the build to
+    # appear in ASC's build list (overrides
+    # skip_waiting_for_build_processing). For first uploads of a new app
+    # that wait is 10-30min and trips the job cap. Skip the changelog
+    # here — set it from the ASC UI, or via a future set_changelog lane.
     upload_to_testflight(
       api_key:                          api_key,
       app_identifier:                   APP_IDS.first,
-      skip_waiting_for_build_processing: true,
-      changelog:                        options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
+      skip_waiting_for_build_processing: true
     )
   end
 end

--- a/packages/mac-app/fastlane/Fastfile
+++ b/packages/mac-app/fastlane/Fastfile
@@ -102,13 +102,17 @@ platform :mac do
       include_symbols:  true
     )
 
+    # Note: passing changelog forces fastlane to wait for the build to
+    # appear in App Store Connect's build list (overrides
+    # skip_waiting_for_build_processing). For first uploads of a new app
+    # that wait is 10-30min and trips the job cap. Skip the changelog
+    # here — set it from the ASC UI, or via a future set_changelog lane.
     upload_to_testflight(
       api_key:                           api_key,
       app_identifier:                    APP_IDS.first,
       app_platform:                      "osx",
       pkg:                               lane_context[SharedValues::PKG_OUTPUT_PATH],
-      skip_waiting_for_build_processing: true,
-      changelog:                         options[:release_notes] || "Automated build #{next_build} from GitHub Actions"
+      skip_waiting_for_build_processing: true
     )
   end
 end


### PR DESCRIPTION
## Summary
- First Mac TestFlight upload succeeded but the GitHub Actions job got killed at the 60-min cap. Upload itself took ~2 min; fastlane then spent 18+ min polling ASC's build list so it could attach the changelog.
- Passing `changelog:` to `upload_to_testflight` silently overrides `skip_waiting_for_build_processing: true` — fastlane has to wait for the build to appear before it can post the changelog.
- Drop the `changelog:` argument from both the iOS and macOS pipelines. Release notes can be set from the App Store Connect UI for now (or via a future dedicated `set_changelog` lane).
- The `release_notes` workflow_dispatch input stays in the YAML so we can wire it back up later without churn.

## Test plan
- [ ] Re-run `macOS → TestFlight` workflow_dispatch — should finish within a few minutes of the IPA/PKG upload completing, no 60-min timeout.
- [ ] Re-run `iOS → TestFlight` workflow_dispatch — same expectation.
- [ ] Confirm the new build shows up in App Store Connect → TestFlight, then add release notes manually in the UI.