### PR TITLE
Cancel in-flight prod deploys when newer main lands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: production-deploy
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- A burst of merges to `main` earlier today queued 4 back-to-back prod deploys behind `cancel-in-progress: false`. Each one runs `docker system prune -af --volumes` + a full container rebuild in `deploy.sh prod`, producing a multi-minute brownout per deploy stacked in series.
- For a prod auto-deploy, older queued deploys are obsolete — `main` is the source of truth and we always want the newest commit live. Flip `cancel-in-progress` to `true` so a newer push supersedes any pending or in-flight deploy in the same concurrency group.
- Trade-off: a deploy interrupted mid-build can leave Docker in a partial state, but the next deploy's `docker system prune -af` cleans that up before rebuilding. Net win vs. queued-brownouts.

## Why now
We just lived through the failure mode. Today's batched PR merges turned what should have been a single "deploy main once" into a queue of 4+ destructive rebuilds. This one-line flip removes the foot-gun.

## Test plan
- [ ] Wait for the current deploy queue (run 27392885601 in_progress + 27392905534 pending) to drain and prod to come back healthy
- [ ] Merge this PR — only one deploy fires
- [ ] Verify `Deploy to Production` workflow on the merge runs to completion and prod stays healthy
- [ ] Later: if two PRs are merged in quick succession to validate the cancel-newer-wins behavior, the older deploy should be marked `cancelled` and only the newer one finishes