### PR TITLE
Fix timer ticking N seconds per second (one increment per useTimer mount)

### DIFF
--- a/packages/ui/src/hooks/useTimer.ts
+++ b/packages/ui/src/hooks/useTimer.ts
@@ -45,7 +45,9 @@ export const useTimer = (): UseTimerReturn => {
     (state: RootState) => state.timer
   );
 
-  // Timer tick effect - only one instance across the app
+  // Timer tick effect — runs once per mounted useTimer caller. Idempotent:
+  // tick() recomputes elapsed from wall-clock startTime, so multiple intervals
+  // converge to the same value rather than racing each other.
   useEffect(() => {
     let interval: NodeJS.Timeout;
     if (isRunning) {

--- a/packages/ui/src/store/slices/__tests__/timerSlice.test.ts
+++ b/packages/ui/src/store/slices/__tests__/timerSlice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import timerSlice, {
   startTimer,
@@ -47,30 +47,51 @@ describe("timerSlice", () => {
   });
 
   describe("reducers", () => {
-    it("should handle tick action when timer is running", () => {
-      const store = createTestStore();
+    it("tick computes elapsed from wall-clock startTime and is idempotent", () => {
+      // Regression test for the "timer adds N seconds per second" bug:
+      // 12 components call useTimer(), each setting up its own 1Hz interval
+      // dispatching tick(). The previous +1-per-call implementation caused
+      // elapsed to grow at N seconds per real second with N mounts. tick()
+      // must now be idempotent — recomputing from startTime so multiple
+      // intervals converge to the same value.
+      vi.useFakeTimers();
+      try {
+        const t0 = new Date("2026-06-12T00:00:00Z");
+        vi.setSystemTime(t0);
 
-      // Set up running state
-      store.dispatch({
-        type: "timer/startTimer/fulfilled",
-        payload: {
-          id: "test-entry",
-          description: "Test work",
-          startTime: new Date().toISOString(),
-          duration: 0,
-          projectId: "project-1",
-          userId: "user-1",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        },
-      });
+        const store = createTestStore();
+        store.dispatch({
+          type: "timer/startTimer/fulfilled",
+          payload: {
+            id: "test-entry",
+            description: "Test work",
+            startTime: t0.toISOString(),
+            duration: 0,
+            projectId: "project-1",
+            userId: "user-1",
+            createdAt: t0.toISOString(),
+            updatedAt: t0.toISOString(),
+          },
+        });
 
-      // Tick the timer
-      store.dispatch(tick());
+        // Advance wall-clock 5 seconds, tick once
+        vi.setSystemTime(new Date(t0.getTime() + 5_000));
+        store.dispatch(tick());
+        expect(store.getState().timer.elapsedTime).toBe(5);
 
-      const state = store.getState().timer;
-      expect(state.elapsedTime).toBe(1);
-      expect(state.currentEntry?.duration).toBe(1);
+        // Idempotency: ticking many more times at the same wall-clock instant
+        // must NOT advance elapsed past 5. Before this fix, 15 calls would
+        // bump elapsed by 15 — the exact symptom users reported in prod.
+        for (let i = 0; i < 15; i++) store.dispatch(tick());
+        expect(store.getState().timer.elapsedTime).toBe(5);
+
+        // Advancing the clock another 3s + ticking lands at 8, not 8+15.
+        vi.setSystemTime(new Date(t0.getTime() + 8_000));
+        store.dispatch(tick());
+        expect(store.getState().timer.elapsedTime).toBe(8);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("should not tick when timer is not running", () => {

--- a/packages/ui/src/store/slices/timerSlice.ts
+++ b/packages/ui/src/store/slices/timerSlice.ts
@@ -112,14 +112,13 @@ const timerSlice = createSlice({
   initialState,
   reducers: {
     tick: (state) => {
+      // Recompute elapsed from wall-clock startTime so multiple useTimer
+      // instances (12 components call it; ~6 mount on Dashboard at once)
+      // converge to the same value. The previous +1-per-call implementation
+      // grew at N seconds per real second with N mounted instances.
       for (const entry of state.runningEntries) {
-        const prev = state.elapsedById[entry.id];
-        const next = Number.isFinite(prev) ? prev + 1 : 1;
-        state.elapsedById[entry.id] = next;
+        state.elapsedById[entry.id] = elapsedFromStart(entry);
       }
-      // Source of truth for live elapsed is elapsedById — don't mutate the
-      // entry.duration field, since that's the stored value at last sync and
-      // mutating it makes "what's the entry's real duration" ambiguous.
       syncMirrors(state);
     },
     syncTimer: (state) => {


### PR DESCRIPTION
## Summary
- Each `useTimer()` call sets up its own `setInterval(tick, 1000)`. The hook comment said "only one instance across the app" — that was wishful thinking, not enforced.
- The `tick` reducer naively did `elapsedById[id] += 1`, so the displayed elapsed grew at **N seconds per real second** with N mounted callers.
- Twelve components call `useTimer()` (App, Timer, TimerWidget, ResumeLastTimer, FavoritesBar, Projects, Dashboard, TimeEntries, plus 4 Electron views). Roughly 5–6 mount simultaneously on Dashboard, more on other pages. Users reported ~15s/sec in prod.
- Fix: make `tick` *idempotent* — recompute elapsed from wall-clock `startTime` (the same logic `syncTimer` already uses). Multiple intervals now converge to the same value rather than racing.
- Hook comment updated to be honest about what's actually happening (multiple intervals, all idempotent).

## Test plan
- [x] New regression test in `timerSlice.test.ts` pins:
  1. Correctness — 5s wall-clock elapsed → `elapsedTime === 5`
  2. **Idempotency** — 15 extra `tick()` dispatches at the same wall-clock instant must NOT advance elapsed past 5
  3. Advancing clock another 3s + tick → 8, not 23
- [ ] After deploy, start a timer in the prod UI on Dashboard and confirm the counter advances at real time (1s per real second)
- [ ] Open the same browser session on multiple tabs — counters stay synchronized rather than racing