### PR TITLE
Keep BuildKit cache between deploys; raise SSH timeout headroom

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,7 +12,7 @@ jobs:
   deploy-pr:
     name: Deploy PR to Staging
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'deploy-staging') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-staging'))
@@ -24,7 +24,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 25m
+          command_timeout: 40m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
@@ -32,7 +32,11 @@ jobs:
 
             echo "=== Freeing disk space ==="
             docker system prune -af --volumes --filter "until=24h" || true
-            docker builder prune -af || true
+            # Filter mirrors the system prune above. Critical because staging
+            # and prod share the same docker daemon / BuildKit instance on this
+            # droplet — an unfiltered prune here wipes the cache mounts that
+            # the prod deploy depends on (see deploy.yml).
+            docker builder prune -af --filter "until=24h" || true
 
             # Clone on first deploy, otherwise just fetch
             if [ ! -d "$DEPLOY_DIR/.git" ]; then
@@ -84,7 +88,7 @@ jobs:
   rollback:
     name: Roll Back Staging to Main
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: >-
       (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-staging') ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-staging'))
@@ -96,14 +100,18 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 25m
+          command_timeout: 40m
           script: |
             set -euo pipefail
             DEPLOY_DIR=~/websites/timetrack-staging
 
             echo "=== Freeing disk space ==="
             docker system prune -af --volumes --filter "until=24h" || true
-            docker builder prune -af || true
+            # Filter mirrors the system prune above. Critical because staging
+            # and prod share the same docker daemon / BuildKit instance on this
+            # droplet — an unfiltered prune here wipes the cache mounts that
+            # the prod deploy depends on (see deploy.yml).
+            docker builder prune -af --filter "until=24h" || true
 
             # Nothing to roll back if staging was never deployed
             if [ ! -d "$DEPLOY_DIR/.git" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Deploy via SSH
@@ -21,7 +21,10 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 25m
+          # Bumped from 25m. Cold-cache web builds were hanging npm ci past
+          # the cap; the builder-prune filter below should keep the cache warm
+          # going forward, but headroom is cheap insurance.
+          command_timeout: 40m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
@@ -29,7 +32,12 @@ jobs:
 
             echo "=== Freeing disk space ==="
             docker system prune -af --volumes --filter "until=24h" || true
-            docker builder prune -af || true
+            # Keep BuildKit cache from the last 24h so the npm ci cache mounts
+            # added in #125 (cd1da9 etc.) actually survive deploy-to-deploy.
+            # Without the filter, every deploy starts from cold cache and the
+            # web container's npm ci over the full monorepo can blow the SSH
+            # command_timeout (root cause of today's PR #143/#144 failures).
+            docker builder prune -af --filter "until=24h" || true
 
             # Clone on first deploy, otherwise just fetch
             if [ ! -d "$DEPLOY_DIR/.git" ]; then


### PR DESCRIPTION
## Summary
PRs #143 and #144 both timed out at the web container's `npm ci` step. Root cause: `docker builder prune -af` (no filter) on every deploy wiped the BuildKit cache mounts added in #125, so `npm ci` always ran from cold cache. With the full monorepo workspaces install, that easily blows past the 25-min SSH `command_timeout`.

Two changes:

1. **Add `--filter "until=24h"` to `docker builder prune`** — mirrors the existing `docker system prune` behavior. Recent cache survives across deploys; only cache older than 24h is reclaimed.
2. **Raise SSH `command_timeout` 25m → 40m** and **job `timeout-minutes` 30 → 45** — belt-and-suspenders for the first cold-cache deploy right after this lands (existing cache was wiped today), and for any future deploy that runs while cache happens to be cold.

## Expected behavior
- **First post-merge deploy** — still cold (current cache is gone). 40-min headroom comfortably covers the ~5-10 min cold web build observed in tonight's failures.
- **Subsequent deploys** — cache mounts hit, `npm ci` drops from minutes to seconds, total deploy back to the 2-3 min it should be.

## Test plan
- [ ] PR review passes
- [ ] On merge, the Deploy to Production workflow completes within the new 40m window
- [ ] The following deploy completes much faster (cache hit on `npm ci`)
- [ ] No regression in the `system prune` behavior — disk usage stays bounded