### PR TITLE
Set LSApplicationCategoryType on Mac app for MAS validation

### DIFF
--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -448,6 +449,7 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Summary
- altool now requires `LSApplicationCategoryType` in the Mac app's Info.plist before accepting a TestFlight upload — the 2026-06-23 macOS pipeline run (#28052646581) was rejected with a 409 for missing it (Xcode also surfaced it as a build warning during prior runs).
- Adds `INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity"` to Debug and Release configs of the TimeTrack Mac target. The project uses `GENERATE_INFOPLIST_FILE = YES`, so the build setting is the correct place to inject it.
- Category can be changed later from App Store Connect; build just needs a valid value present.

## Test plan
- [ ] Merge to main
- [ ] Re-trigger `macOS → TestFlight` workflow on main
- [ ] Verify altool no longer returns the 409 and the pkg upload completes