### PR TITLE
Pre-answer export compliance for Mac app

### DIFF
--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -449,6 +450,7 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
## Summary
- Mac TestFlight build 1.0 (2) ended up in "Missing Compliance" state because ASC asks every new upload whether it uses non-exempt encryption, and the answer can't be set from the current ASC web UI on this account.
- Bakes the answer into `Info.plist` via `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` on both Debug and Release. ASC reads the key during build processing and skips the compliance prompt entirely; subsequent builds flip straight to "Ready to Test".
- TimeTrack only uses standard HTTPS / system crypto via URLSession — exempt under Apple's export rules.

## Test plan
- [ ] Merge to main
- [ ] Re-trigger `macOS → TestFlight` workflow on main
- [ ] After processing, ASC build status shows "Ready to Test" without manual compliance answer