### PR TITLE
Inject ITSAppUsesNonExemptEncryption via build-phase script

### DIFF
--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -269,15 +269,18 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = "Inject ITSAppUsesNonExemptEncryption";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+				"$(DERIVED_FILE_DIR)/ITSAppUsesNonExemptEncryption.stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Xcode's INFOPLIST_KEY_<key> mechanism silently drops boolean values\n# of NO during plist synthesis, so we inject ITSAppUsesNonExemptEncryption\n# directly into the built app's Info.plist before code-signing.\nset -e\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"error: Info.plist not found at $PLIST\" >&2\n  exit 1\nfi\n/usr/libexec/PlistBuddy -c \"Add :ITSAppUsesNonExemptEncryption bool false\" \"$PLIST\" 2>/dev/null \\\n  || /usr/libexec/PlistBuddy -c \"Set :ITSAppUsesNonExemptEncryption false\" \"$PLIST\"\n";
+			shellScript = "# Xcode's INFOPLIST_KEY_<key> mechanism silently drops boolean values\n# of NO during plist synthesis, so we inject ITSAppUsesNonExemptEncryption\n# directly into the built app's Info.plist before code-signing.\n#\n# inputPaths/outputPaths above are required so User Script Sandboxing\n# allowlists the .app's Info.plist for read/write — otherwise PlistBuddy\n# silently no-ops under the sandbox and ASC parks the build in\n# Missing Compliance with no visible build error.\n#\n# The stamp file is a separate \"virtual output\" that Xcode's build system\n# requires when an input is also a mutable output, so the dependency graph\n# has a non-self-referential node to track.\nset -e\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"error: Info.plist not found at $PLIST\" >&2\n  exit 1\nfi\n/usr/libexec/PlistBuddy -c \"Add :ITSAppUsesNonExemptEncryption bool false\" \"$PLIST\" 2>/dev/null \\\n  || /usr/libexec/PlistBuddy -c \"Set :ITSAppUsesNonExemptEncryption false\" \"$PLIST\"\n# Verify the key actually landed — protects against a future sandbox/path regression\n# producing a silent no-op (the same failure mode this PR is fixing).\nVALUE=$(/usr/libexec/PlistBuddy -c \"Print :ITSAppUsesNonExemptEncryption\" \"$PLIST\" 2>/dev/null || true)\nif [ \"$VALUE\" != \"false\" ]; then\n  echo \"error: ITSAppUsesNonExemptEncryption not set to false in $PLIST (got: '$VALUE')\" >&2\n  exit 1\nfi\nmkdir -p \"${DERIVED_FILE_DIR}\"\ntouch \"${DERIVED_FILE_DIR}/ITSAppUsesNonExemptEncryption.stamp\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
+++ b/packages/mac-app/TimeTrack.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 				D0000001000000013 /* Sources */,
 				D0000001000000002 /* Frameworks */,
 				D0000001000000014 /* Resources */,
+				38E1C0DE00000001FA5E0001 /* Inject ITSAppUsesNonExemptEncryption */,
 			);
 			buildRules = (
 			);
@@ -257,6 +258,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		38E1C0DE00000001FA5E0001 /* Inject ITSAppUsesNonExemptEncryption */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Inject ITSAppUsesNonExemptEncryption";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Xcode's INFOPLIST_KEY_<key> mechanism silently drops boolean values\n# of NO during plist synthesis, so we inject ITSAppUsesNonExemptEncryption\n# directly into the built app's Info.plist before code-signing.\nset -e\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"error: Info.plist not found at $PLIST\" >&2\n  exit 1\nfi\n/usr/libexec/PlistBuddy -c \"Add :ITSAppUsesNonExemptEncryption bool false\" \"$PLIST\" 2>/dev/null \\\n  || /usr/libexec/PlistBuddy -c \"Set :ITSAppUsesNonExemptEncryption false\" \"$PLIST\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		D0000001000000013 /* Sources */ = {
@@ -422,7 +445,6 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -450,7 +472,6 @@
 				DEVELOPMENT_TEAM = HL8D756J57;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
## Summary
- Xcode's `INFOPLIST_KEY_<key>` mechanism silently drops boolean values of `NO` during plist synthesis. PR #147 set `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` but extraction of the resulting `.pkg`'s `Info.plist` confirmed the key was never written, leaving builds 1.0 (2) and 1.0 (3) parked in "Missing Compliance" with no ASC UI fallback for this account.
- Adds a Run Script build phase to the Mac target that uses `PlistBuddy` to inject `ITSAppUsesNonExemptEncryption = false` into the built `.app`'s `Info.plist` after the synthesized plist is written but before code-signing.
- Removes the no-op `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` lines that PR #147 added.

## Why a build script and not a static Info.plist
- Static `Info.plist` migration would require declaring every Xcode-synthesized key (`CFBundleName`, `CFBundleVersion`, etc.) by hand — bigger diff, more failure surface.
- The build script is surgical, runs after `Copy Bundle Resources` and before the implicit codesign, and leaves every other synthesized key untouched.

## Truthfulness of the declaration
TimeTrack's only crypto usage is `Security` framework (Keychain for the JWT) and TLS via URLSession / Starscream / Socket.IO — all exempt secure-comms / authentication uses under EAR §740.17(b)(2). Confirmed in the prior PR #147 review.

## Test plan
- [ ] Merge to main
- [ ] Re-trigger `macOS → TestFlight` workflow on main
- [ ] Download the new `.pkg` artifact and confirm `PlistBuddy -c "Print :ITSAppUsesNonExemptEncryption"` returns `false`
- [ ] Confirm ASC shows the new build as "Ready to Test" instead of "Missing Compliance"