### PR TITLE
Document MAS TestFlight gotchas + iOS resume checklist

### DIFF
--- a/packages/ios-app/TESTFLIGHT_SETUP.md
+++ b/packages/ios-app/TESTFLIGHT_SETUP.md
@@ -138,7 +138,7 @@ The first run takes ~15 minutes (cold caches). Subsequent runs are ~8 minutes. W
 
 ---
 
-## Repeat for macOS
+## Sibling: macOS pipeline (already shipping)
 
 The macOS pipeline (`packages/mac-app`) reuses the same:
 - Apple team (`HL8D756J57`)
@@ -147,11 +147,49 @@ The macOS pipeline (`packages/mac-app`) reuses the same:
 - `MATCH_PASSWORD`, `MATCH_KEYCHAIN_PASSWORD`, `MATCH_SSH_PRIVATE_KEY` secrets
 
 What's different per platform:
-- Bundle ID (`com.orbitalabworks.timetrack.mac`)
-- `match` is invoked with `macos` platform (see the Mac Fastfile)
-- A separate workflow file: `.github/workflows/build-mac-testflight.yml`
+- The same `com.orbitalabworks.timetrack` bundle ID — **Universal Purchase**, one ASC app record covers iOS + macOS, customers cross-buy. (Earlier iterations used a `.mac` suffix; that's gone.)
+- `match` is invoked with `macos` platform + `additional_cert_types: ["mac_installer_distribution"]` (Mac App Store needs a separate installer cert).
+- A separate workflow file: `.github/workflows/build-mac-testflight.yml`.
 
-That work lives in PR B. Once both PRs are merged and step 6 is run for `mac`, you'll have one button per platform.
+The Mac side has hit four MAS-specific gotchas that iOS will also hit on its first upload — see "Gotchas to anticipate when iOS unblocks" below before retriggering the iOS workflow.
+
+---
+
+## Current iOS pipeline state (as of 2026-06-24)
+
+**Paused.** All infrastructure is set up except the items below. Resume when Pablo is available.
+
+### Blockers (require the Account Holder)
+
+1. **Register two extension bundle IDs** in the developer portal under the Orbital Labworks team:
+   - `com.orbitalabworks.timetrack.watchkitapp`
+   - `com.orbitalabworks.timetrack.liveactivity`
+2. **Register the App Group** `group.com.timetrack.shared` and tick it as a capability on all three iOS App IDs (main app + the two extensions). The watchOS app and Live Activity extension need it to share Keychain auth state with the main app.
+
+The main app's `com.orbitalabworks.timetrack` App ID is already registered (shared with macOS via Universal Purchase).
+
+### Resumption checklist (when Pablo is done)
+
+1. Confirm all three App IDs exist and have the App Group ticked under their Capabilities tab.
+2. `cd packages/ios-app && bundle exec fastlane ios match_setup` — seeds iOS distribution certs and profiles for all three bundle IDs. Requires the four env vars from `~/.appstoreconnect/match-passwords.env` plus the three `APP_STORE_CONNECT_API_KEY_*` env vars.
+3. **Apply the preemptive Info.plist fixes from the Mac side** to the iOS target's `project.pbxproj` (see next section). Skipping this guarantees the first iOS upload lands in the same Missing Compliance / 409 validation traps the Mac side hit on builds 1.0 (1) through 1.0 (3).
+4. Trigger the `iOS → TestFlight` workflow on main. Job should complete in ~10 min.
+
+---
+
+## Gotchas to anticipate when iOS unblocks
+
+The Mac pipeline went through four sequential failures between 2026-06-10 and 2026-06-23 because Apple tightened MAS validation rules and Xcode quietly drops certain build settings. Apply the same fixes to the iOS `project.pbxproj` *before* the first iOS upload — see `packages/mac-app/TESTFLIGHT_SETUP.md` "Gotchas hit and fixed" for the full story; brief version:
+
+1. **`LSApplicationCategoryType` is required.** Add `INFOPLIST_KEY_LSApplicationCategoryType` (likely `"public.app-category.productivity"` for iOS too) to Debug + Release configs of the main app target.
+
+2. **`ITSAppUsesNonExemptEncryption` is required.** Xcode silently strips boolean `NO` from `INFOPLIST_KEY_*` settings during plist synthesis, so the obvious approach won't work. The Mac side uses a Run Script build phase that calls `PlistBuddy` to inject the key into the built `.app`'s `Info.plist`. Port that phase to the iOS target verbatim (UUID can be reused; phase ordering, `inputPaths`/`outputPaths` sandbox allowlist, virtual stamp output, and read-back verification all transfer 1:1). The Mac Fastfile already handles three targets (main app + Watch + Live Activity extension) for `update_code_signing_settings`; the Run Script only needs to run on the main app target (the extensions inherit `ITSAppUsesNonExemptEncryption` from the bundling app per Apple's docs, but verify).
+
+3. **`CODE_SIGN_STYLE = Manual` override at build time.** Already in place in the iOS Fastfile for all three shipping targets (Timetrack, Watch app, LiveActivity extension). Don't remove it — the pbxproj stays Automatic for local dev, the Fastfile flips to Manual for CI.
+
+4. **No `changelog:` on `upload_to_testflight`.** Already removed. Don't re-add it (60-min job-cap risk on first uploads of a new app).
+
+The Mac doc also covers `output_name` without `.pkg`, the `lane_context` pkg path, and the `.p8` materialization step — those are already handled in the iOS workflow file too, but the same caveats apply if anyone refactors.
 
 ---
 

--- a/packages/ios-app/TESTFLIGHT_SETUP.md
+++ b/packages/ios-app/TESTFLIGHT_SETUP.md
@@ -10,7 +10,7 @@ App Group: `group.com.timetrack.shared`.
 
 ## Step 1 — Pablo (Account Holder)
 
-Forward the message at `PABLO-BOOTSTRAP-MESSAGE.md` (repo root, gitignored). He owes you:
+Forward the message at `PABLO-BOOTSTRAP-MESSAGE.md` (repo root, **gitignored** — does not survive a fresh clone; if missing, reconstruct from the bootstrap items below). Note: the on-disk copy still mentions a fourth bundle ID `com.orbitalabworks.timetrack.mac` as historical residue from a pre-Universal-Purchase plan — disregard, the Mac and iOS apps share `com.orbitalabworks.timetrack`. He owes you:
 
 1. Acceptance of the updated Apple Developer Program License Agreement at <https://developer.apple.com/account>.
 2. An App Store Connect **API Key** (role: **App Manager**, "Access to Cloud Managed Distribution Certificate" enabled). He sends you the `.p8` file, the **Key ID**, and the **Issuer ID**.
@@ -170,10 +170,13 @@ The main app's `com.orbitalabworks.timetrack` App ID is already registered (shar
 
 ### Resumption checklist (when Pablo is done)
 
-1. Confirm all three App IDs exist and have the App Group ticked under their Capabilities tab.
-2. `cd packages/ios-app && bundle exec fastlane ios match_setup` — seeds iOS distribution certs and profiles for all three bundle IDs. Requires the four env vars from `~/.appstoreconnect/match-passwords.env` plus the three `APP_STORE_CONNECT_API_KEY_*` env vars.
-3. **Apply the preemptive Info.plist fixes from the Mac side** to the iOS target's `project.pbxproj` (see next section). Skipping this guarantees the first iOS upload lands in the same Missing Compliance / 409 validation traps the Mac side hit on builds 1.0 (1) through 1.0 (3).
-4. Trigger the `iOS → TestFlight` workflow on main. Job should complete in ~10 min.
+1. Confirm all three App IDs exist and have the App Group ticked, in the developer portal at <https://developer.apple.com/account/resources/identifiers/list> → select each App ID → **Capabilities** tab → verify "App Groups" is checked AND the specific `group.com.timetrack.shared` group is selected (the two are separate steps in Apple's UI — easy to miss the second). If Pablo only registered the bundle IDs without ticking App Groups, ping him to edit each identifier.
+2. **Check whether iOS Match was already seeded before re-running.** `git ls-remote git@github.com:alfredoreduarte/timetrack-signing.git | grep ios` — if profiles for the three iOS bundle IDs already exist under `profiles/appstore/ios/` in that repo, skip step 3 (or use the readonly `match_sync` lane). Otherwise:
+3. `cd packages/ios-app && bundle exec fastlane ios match_setup` — seeds iOS distribution certs and profiles for all three bundle IDs. Requires two env vars from `~/.appstoreconnect/match-passwords.env` (`MATCH_PASSWORD`, `MATCH_KEYCHAIN_PASSWORD`) plus the three `APP_STORE_CONNECT_API_KEY_*` env vars (set them via `source ~/.appstoreconnect/match-passwords.env` and an export-from-1Password / similar for the API key triple).
+4. **Apply the preemptive Info.plist fixes from the Mac side** to the iOS target's `project.pbxproj` (see next section). Skipping this guarantees the first iOS upload lands in the same Missing Compliance / 409 validation traps the Mac side hit on builds 1.0 (1) through 1.0 (3).
+5. Trigger the `iOS → TestFlight` workflow on main. Job should complete in ~10 min.
+
+The iOS Xcode project lives one directory deeper than the Mac project: `packages/ios-app/Timetrack/Timetrack.xcodeproj/project.pbxproj` (note the extra `Timetrack/` level), vs. the Mac's `packages/mac-app/TimeTrack.xcodeproj/project.pbxproj`.
 
 ---
 
@@ -183,7 +186,20 @@ The Mac pipeline went through four sequential failures between 2026-06-10 and 20
 
 1. **`LSApplicationCategoryType` is required.** Add `INFOPLIST_KEY_LSApplicationCategoryType` (likely `"public.app-category.productivity"` for iOS too) to Debug + Release configs of the main app target.
 
-2. **`ITSAppUsesNonExemptEncryption` is required.** Xcode silently strips boolean `NO` from `INFOPLIST_KEY_*` settings during plist synthesis, so the obvious approach won't work. The Mac side uses a Run Script build phase that calls `PlistBuddy` to inject the key into the built `.app`'s `Info.plist`. Port that phase to the iOS target verbatim (UUID can be reused; phase ordering, `inputPaths`/`outputPaths` sandbox allowlist, virtual stamp output, and read-back verification all transfer 1:1). The Mac Fastfile already handles three targets (main app + Watch + Live Activity extension) for `update_code_signing_settings`; the Run Script only needs to run on the main app target (the extensions inherit `ITSAppUsesNonExemptEncryption` from the bundling app per Apple's docs, but verify).
+2. **`ITSAppUsesNonExemptEncryption` is required.** Xcode silently strips boolean `NO` from `INFOPLIST_KEY_*` settings during plist synthesis, so the obvious approach won't work. The Mac side uses a Run Script build phase that calls `PlistBuddy` to inject the key into the built `.app`'s `Info.plist`. Port that phase to the iOS main app target verbatim. The complete `PBXShellScriptBuildPhase` block to copy lives in the Mac pbxproj at `packages/mac-app/TimeTrack.xcodeproj/project.pbxproj` lines 263–284 (the entry with UUID `38E1C0DE00000001FA5E0001`), and the reference inside the target's `buildPhases` array is at line 200. Pick a fresh UUID for the iOS pbxproj (any unused 24-hex-char string), copy the whole block, and append the new reference as the **last** entry in the iOS app target's `buildPhases` (after Sources/Frameworks/Resources, before Xcode's implicit codesign step). Keep all four invariants from the Mac side: phase ordering, `inputPaths`/`outputPaths` sandbox allowlist, the `$(DERIVED_FILE_DIR)/...stamp` virtual output, and the in-script read-back verification.
+
+   Apple's docs say extensions inherit `ITSAppUsesNonExemptEncryption` from the bundling app, so the Run Script only needs to run on the main app target. **Verify after the first iOS TestFlight upload**: if the watchOS or Live Activity extension lands in Missing Compliance separately, port the same Run Script phase to those targets too.
+
+   The iOS Fastfile already iterates over three target/bundle-id pairs for `update_code_signing_settings` (the Mac Fastfile only signs one target, since the Mac app has no extensions); the new Run Script doesn't need any Fastfile changes — it's a target build phase, run by xcodebuild during archive.
+
+   **Local verification** after porting and before the CI run:
+   ```bash
+   xcodebuild -project Timetrack/Timetrack.xcodeproj -scheme Timetrack -configuration Debug \
+     -derivedDataPath /tmp/ios-verify CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO build
+   /usr/libexec/PlistBuddy -c "Print :ITSAppUsesNonExemptEncryption" \
+     /tmp/ios-verify/Build/Products/Debug-iphonesimulator/Timetrack.app/Info.plist
+   # → must print: false
+   ```
 
 3. **`CODE_SIGN_STYLE = Manual` override at build time.** Already in place in the iOS Fastfile for all three shipping targets (Timetrack, Watch app, LiveActivity extension). Don't remove it — the pbxproj stays Automatic for local dev, the Fastfile flips to Manual for CI.
 

--- a/packages/mac-app/TESTFLIGHT_SETUP.md
+++ b/packages/mac-app/TESTFLIGHT_SETUP.md
@@ -67,3 +67,58 @@ The `macOS → TestFlight` workflow reads the same secret names the iOS workflow
 - **Apple cert quirk.** Mac installer certificates expire on a slightly different cadence from application certificates. If `upload_to_testflight` fails with `unable to find installer signing identity`, rerun `bundle exec fastlane mac match_setup` to refresh.
 - **Catalyst.** This app is native AppKit + SwiftUI, not Mac Catalyst. It shares the iOS bundle ID for Universal Purchase but is built from the Mac Xcode project as a separate native binary.
 - **Build numbers.** Auto-incremented from TestFlight's latest macOS build, independently of the iOS app's build number — TestFlight tracks build numbers per platform.
+
+---
+
+## Installing a TestFlight build locally
+
+TestFlight for Mac apps requires Apple's dedicated **TestFlight** Mac app (separate from iOS TestFlight, free on the Mac App Store). End-to-end install flow once a build is uploaded:
+
+1. Wait for ASC to finish processing the build. First Mac build for a brand-new app routinely takes 15–30 minutes to process, even after fastlane reports the upload succeeded. Watch its status under TestFlight → macOS → Builds.
+2. Answer (or pre-answer in code) the **export compliance** question — see the gotcha section below.
+3. In **Internal Testing → \<your group\> → Builds**, click **+** and attach the build. The group does not auto-pull builds; you have to attach each one once (subsequent uploads do auto-roll into existing groups).
+4. Open the TestFlight Mac app, sign in with the Apple ID added as an internal tester, and click **Install** next to TimeTrack. Installs to `/Applications/TimeTrack.app` and auto-updates on every new TestFlight build.
+
+> Adding internal testers requires an App Store Connect role of **App Manager**, **Admin**, or **Account Holder** on the Apple team. Developer-only roles cannot manage TestFlight testers. If your user picker is empty, check **Users and Access** in ASC.
+
+---
+
+## Gotchas hit and fixed (state as of 2026-06-24)
+
+Everything in this section is already wired up in the repo — the gotchas are documented for context (and so the iOS pipeline can pre-emptively avoid the same traps).
+
+### Info.plist keys ASC requires (PRs #146, #148)
+
+altool / TestFlight validation now requires two Info.plist keys for every Mac App Store upload. Missing either silently lands the build in "Missing Compliance" or rejects the upload with a 409. Both are handled in `TimeTrack.xcodeproj/project.pbxproj`:
+
+| Key | How it's set | Why it can't be set the obvious way |
+|---|---|---|
+| `LSApplicationCategoryType` | `INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity"` on Debug+Release | (none — the build setting works for string values) |
+| `ITSAppUsesNonExemptEncryption` | **Run Script build phase "Inject ITSAppUsesNonExemptEncryption"** that uses `PlistBuddy` to write `false` into the built `.app`'s `Info.plist` | Xcode silently **drops boolean `NO`** from `INFOPLIST_KEY_*` settings during plist synthesis — the obvious `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` ships an `.app` without the key. ASC's web UI also has no fallback form for accounts below App Manager role. |
+
+The Run Script phase has four moving parts you must keep together if anyone edits it:
+
+1. **Phase order**: must be the last phase in `buildPhases`, after Sources/Frameworks/Resources, so the synthesized `Info.plist` already exists and the implicit codesign step still happens *after* the mutation.
+2. **Sandbox allowlist**: `inputPaths` and `outputPaths` both list `$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)`. Without this, `ENABLE_USER_SCRIPT_SANDBOXING = YES` (Xcode 15+ default) denies the write and PlistBuddy silently no-ops — the same silent-fail mode that hit the first attempted fix.
+3. **Virtual stamp output**: `outputPaths` also lists `$(DERIVED_FILE_DIR)/ITSAppUsesNonExemptEncryption.stamp`. Xcode 26 rejects builds with "mutable output but no other virtual output node" when input == output; the stamp gives the dependency graph a non-self-referential node.
+4. **Read-back verification**: the script `Print`s the key after writing and hard-exits with a non-zero status if the value isn't `false`. Catches any future sandbox/path regression loudly instead of shipping another silent-fail build.
+
+### CI pipeline quirks (Fastfile + workflow)
+
+These are already baked in but document why the Fastfile looks the way it does:
+
+- **`CODE_SIGN_STYLE = Manual` override at build time.** The pbxproj stays on `Automatic` so local Xcode dev works against your Apple ID. The Fastfile calls `update_code_signing_settings` to flip to Manual just before `build_mac_app`, pointing at the Match-managed `Apple Distribution` cert and `match AppStore com.orbitalabworks.timetrack macos` profile. Removing this override breaks CI with "No signing certificate 'Mac Development' found".
+- **`output_name: "TimeTrack"` (no `.pkg` suffix).** `gym` appends `.pkg`. If you write `"TimeTrack.pkg"` you end up looking for `TimeTrack.pkg.pkg`.
+- **`pkg: lane_context[SharedValues::PKG_OUTPUT_PATH]` in `upload_to_testflight`.** `File.expand_path("build/TimeTrack.pkg")` resolves relative to `packages/mac-app/fastlane/`, not `packages/mac-app/`. Use the lane context value instead.
+- **`.p8` materialized to disk** in the GH Actions step `Materialize App Store Connect API key`. altool can't read the in-memory `.p8` fastlane writes via `is_key_content_base64: true`; it reliably reads from `~/.appstoreconnect/private_keys/AuthKey_<id>.p8`. The workflow base64-decodes the secret to that path and exports `ASC_API_KEY_PATH`; the Fastfile prefers `key_filepath` when that env var is set.
+- **No `changelog:` on `upload_to_testflight`.** Passing `changelog:` forces fastlane to wait for the build to appear in ASC's build list (overriding `skip_waiting_for_build_processing: true`). For a first upload of a new app that wait is 10–30 min and trips the 60-min job cap. Release notes get set from the ASC UI, or via a separate `set_changelog` lane in the future.
+
+### Apple's MAS validation tightened twice between 2026-06-10 and 2026-06-23
+
+Both `LSApplicationCategoryType` and `ITSAppUsesNonExemptEncryption` were unenforced when the first successful Mac TestFlight build went up on 2026-06-10. By 2026-06-23 both were required. Treat the gotcha section as a moving target — Apple may add another required key without warning.
+
+---
+
+## Sibling state: iOS pipeline
+
+iOS is paused waiting on Pablo (Account Holder) to register two extension bundle IDs and the App Group. Everything else is set up. See `packages/ios-app/TESTFLIGHT_SETUP.md` for the resumption checklist — it includes a preemptive port of the Mac gotchas above so the iOS pipeline doesn't re-derive them.

--- a/packages/mac-app/TESTFLIGHT_SETUP.md
+++ b/packages/mac-app/TESTFLIGHT_SETUP.md
@@ -81,15 +81,25 @@ TestFlight for Mac apps requires Apple's dedicated **TestFlight** Mac app (separ
 
 > Adding internal testers requires an App Store Connect role of **App Manager**, **Admin**, or **Account Holder** on the Apple team. Developer-only roles cannot manage TestFlight testers. If your user picker is empty, check **Users and Access** in ASC.
 
+### "I added myself but no builds appear" — diagnostic flow
+
+This was the exact scenario hit on 2026-06-23. Walk these in order:
+
+1. **ASC role.** Open **Users and Access** in ASC. Your Apple ID must have App Manager / Admin / Account Holder. Developer-only can't see TestFlight builds at all.
+2. **Build still processing.** TestFlight → Builds → macOS. The build must show **Complete** (green check) in the Build Uploads table, not Processing / Failed. First Mac build for a new app routinely takes 15–30 min to process even after fastlane reports the upload succeeded.
+3. **Export compliance.** Below Build Uploads, the per-version Builds table must not say **Missing Compliance**. If it does, either answer the question in the build's Test Information tab (only visible to App Manager+ roles, in some account states the form is absent entirely) or — better — bake the answer into Info.plist via the build script described in the gotcha section below. Builds in Missing Compliance never appear to testers regardless of group membership.
+4. **Build attached to the group.** Internal Testing → \<your group\> → **Builds** tab → click **+** → pick the build. The group has its own per-build attach step; it does NOT auto-pull builds. (The Testers tab on the group is for adding people; the Builds tab is for attaching builds. These are independent.)
+5. **Correct TestFlight client.** Apple's TestFlight app for Mac is **distinct** from the iOS TestFlight app, free on the Mac App Store, developer "Apple". Sign in with the same Apple ID that's listed under your Internal Testing group's testers.
+
 ---
 
 ## Gotchas hit and fixed (state as of 2026-06-24)
 
 Everything in this section is already wired up in the repo — the gotchas are documented for context (and so the iOS pipeline can pre-emptively avoid the same traps).
 
-### Info.plist keys ASC requires (PRs #146, #148)
+### Info.plist keys ASC requires (PRs #146, #147 [failed attempt], #148)
 
-altool / TestFlight validation now requires two Info.plist keys for every Mac App Store upload. Missing either silently lands the build in "Missing Compliance" or rejects the upload with a 409. Both are handled in `TimeTrack.xcodeproj/project.pbxproj`:
+altool / TestFlight validation now requires two Info.plist keys for every Mac App Store upload. Missing either silently lands the build in "Missing Compliance" or rejects the upload with a 409. PR #147 attempted the obvious `INFOPLIST_KEY_*` route for the encryption key and silently failed (Xcode drops boolean `NO`); PR #148 replaced it with the build-script approach below. Both required keys are handled in `TimeTrack.xcodeproj/project.pbxproj`:
 
 | Key | How it's set | Why it can't be set the obvious way |
 |---|---|---|
@@ -116,6 +126,18 @@ These are already baked in but document why the Fastfile looks the way it does:
 ### Apple's MAS validation tightened twice between 2026-06-10 and 2026-06-23
 
 Both `LSApplicationCategoryType` and `ITSAppUsesNonExemptEncryption` were unenforced when the first successful Mac TestFlight build went up on 2026-06-10. By 2026-06-23 both were required. Treat the gotcha section as a moving target — Apple may add another required key without warning.
+
+If a future build fails the same way, the diagnostic phrase to grep for in the fastlane log is `Validation failed (409)` (for the altool reject path) or "Missing Compliance" in the ASC build list (for the silent-park path). Both surface the missing Info.plist key name explicitly in the error message; the fix template is the same as either the `INFOPLIST_KEY_*` setting (for string values) or the Run Script + PlistBuddy phase (for booleans that need to be `NO/false`).
+
+---
+
+## Design decisions and trade-offs
+
+Captured so a future engineer doesn't re-litigate the same calls:
+
+- **Universal Purchase** (one bundle ID for iOS + macOS, one ASC app record). Trade-off: customers who buy on one platform get the other free, the App Store listing is a single page covering both platforms, and there's one set of release notes / screenshots / ratings to maintain. The cost is no per-platform pricing (one price covers both, or you set both free). For a time tracker we want the cross-buy, and per-platform pricing isn't useful, so Universal Purchase is the right call. Reversing would require a new ASC record + a new bundle ID for one of the platforms.
+- **Category = `public.app-category.productivity`** matches the existing TimeTrack iOS app and the user-facing product positioning (time tracking is productivity, not utilities or business). Changing it is non-destructive: edit the build setting, ship a new build, and ASC updates the listing's category. Alternative reasonable categories: `public.app-category.business` (if pivoting to team / invoicing positioning) or `public.app-category.utilities` (if narrowing scope).
+- **Run Script + PlistBuddy** over `GENERATE_INFOPLIST_FILE = NO` + a checked-in Info.plist. The static-plist alternative is conventionally cleaner, but it requires migrating every key Xcode currently synthesizes (CFBundleName, CFBundleExecutable, CFBundleSupportedPlatforms, CFBundlePackageType, etc.) into a hand-maintained file — significant diff, every miss is a runtime regression, and future synthesizable keys (Xcode adds them periodically) won't auto-flow into the plist. The Run Script approach is surgical: it leaves the synthesizer in charge of everything except the one key it can't write correctly. If Apple ever adds more boolean-NO keys we need to set, the same Run Script can grow more `PlistBuddy Add` lines.
 
 ---
 


### PR DESCRIPTION
## Summary
Mac TestFlight is now shipping after four PRs (#146, #147 [attempt], #148, plus the original infra) and several Apple-tightened-validation surprises. This PR captures everything we learned so the next time anyone touches this — particularly when iOS unblocks — they don't re-derive the gotcha trail.

### `packages/mac-app/TESTFLIGHT_SETUP.md`
- New **Installing a TestFlight build locally** section: TestFlight Mac app is separate from iOS TestFlight, role requirements for managing testers, the per-build attach-to-group step that's easy to miss.
- New **Gotchas hit and fixed (state as of 2026-06-24)** section covering both Info.plist requirements (`LSApplicationCategoryType`, `ITSAppUsesNonExemptEncryption`), why `INFOPLIST_KEY_*` doesn't work for boolean `NO`, the four constraints on the Run Script build phase (ordering, sandbox allowlist, virtual stamp output, read-back verify), and the four pre-existing CI pipeline quirks (signing style override, `output_name` no-`.pkg`, `lane_context` pkg path, `.p8` materialization, dropped changelog).
- Pointer to the iOS doc for current iOS state.

### `packages/ios-app/TESTFLIGHT_SETUP.md`
- Fix stale `.mac` bundle ID suffix in the macOS sibling section (Universal Purchase means the same bundle ID).
- New **Current iOS pipeline state (as of 2026-06-24)** section: paused, blockers (Pablo registering the two extension bundle IDs + App Group), resumption checklist.
- New **Gotchas to anticipate when iOS unblocks** section porting the Mac gotcha list so the iOS pipeline doesn't repeat the same failures.

## Test plan
- [ ] Read both files end-to-end as a future engineer resuming the iOS pipeline cold.
- [ ] Verify the iOS resumption checklist matches the actual blockers tracked in TODOs and memory.
- [ ] Verify all file paths, UUIDs, and build settings cited match the actual repo state.