### PR TITLE
Fix data-loss footgun: prune images not volumes in deploys

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,8 +31,12 @@ jobs:
             DEPLOY_DIR=~/websites/timetrack-staging
 
             echo "=== Freeing disk space ==="
-            docker system prune -af --volumes --filter "until=24h" || true
-            # Filter mirrors the system prune above. Critical because staging
+            # Images only — never --volumes. The until= filter does NOT apply to
+            # volumes, so `system prune --volumes` can delete postgres_data if the
+            # DB container is briefly down during a deploy (data-loss footgun on a
+            # box whose only backup is a pg_dump to the same disk).
+            docker image prune -af --filter "until=24h" || true
+            # Filter mirrors the image prune above. Critical because staging
             # and prod share the same docker daemon / BuildKit instance on this
             # droplet — an unfiltered prune here wipes the cache mounts that
             # the prod deploy depends on (see deploy.yml).
@@ -106,8 +110,12 @@ jobs:
             DEPLOY_DIR=~/websites/timetrack-staging
 
             echo "=== Freeing disk space ==="
-            docker system prune -af --volumes --filter "until=24h" || true
-            # Filter mirrors the system prune above. Critical because staging
+            # Images only — never --volumes. The until= filter does NOT apply to
+            # volumes, so `system prune --volumes` can delete postgres_data if the
+            # DB container is briefly down during a deploy (data-loss footgun on a
+            # box whose only backup is a pg_dump to the same disk).
+            docker image prune -af --filter "until=24h" || true
+            # Filter mirrors the image prune above. Critical because staging
             # and prod share the same docker daemon / BuildKit instance on this
             # droplet — an unfiltered prune here wipes the cache mounts that
             # the prod deploy depends on (see deploy.yml).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,11 @@ jobs:
             DEPLOY_DIR=~/websites/timetrack-production
 
             echo "=== Freeing disk space ==="
-            docker system prune -af --volumes --filter "until=24h" || true
+            # Images only — never --volumes. The until= filter does NOT apply to
+            # volumes, so `system prune --volumes` can delete postgres_data if the
+            # DB container is briefly down during a deploy (data-loss footgun on a
+            # box whose only backup is a pg_dump to the same disk).
+            docker image prune -af --filter "until=24h" || true
             # Keep BuildKit cache from the last 24h so the npm ci cache mounts
             # added in #125 (cd1da9 etc.) actually survive deploy-to-deploy.
             # Without the filter, every deploy starts from cold cache and the


### PR DESCRIPTION
## Problem
Both deploy workflows run `docker system prune -af --volumes --filter "until=24h"` to free disk before building. The `until=` filter **does not apply to volume removal** — `--volumes` removes any volume not currently attached to a running container, regardless of age. On this single shared droplet, if the `postgres` container is briefly down during a deploy window, that line can delete the `postgres_data` volume — and the only backup is a `pg_dump` written to the same disk.

## Fix
Replace `docker system prune -af --volumes` with `docker image prune -af --filter "until=24h"` (images only, never volumes) in:
- `.github/workflows/deploy.yml`
- `.github/workflows/deploy-staging.yml` (both the `deploy-pr` and `rollback` jobs)

Surgical, standalone safety fix. The broader move of builds off the droplet (issue #149) is separate.

## Test plan
- [ ] CI workflows parse (YAML valid).
- [ ] Next staging/prod deploy frees disk via `docker image prune` and completes normally.
- [ ] Confirm `postgres_data` / `redis_data` volumes are untouched after a deploy (`docker volume ls`).

Refs #149