### PR TITLE
Build prod images in CI and pull on the droplet (issue #149)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,17 @@ pnpm-debug.log*
 .env.test.local
 .env.production.local
 docker.env
+docker.staging.env
+docker.*.env
+
+# Secrets & signing keys (must never enter an image layer, esp. once
+# staging also builds in CI / pushes to a registry)
+*.pem
+*.p8
+AuthKey_*.p8
+*.mobileprovision
+github_key*
+**/fastlane/.env*
 
 # Git
 .git

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,10 +36,9 @@ jobs:
             # DB container is briefly down during a deploy (data-loss footgun on a
             # box whose only backup is a pg_dump to the same disk).
             docker image prune -af --filter "until=24h" || true
-            # Filter mirrors the image prune above. Critical because staging
-            # and prod share the same docker daemon / BuildKit instance on this
-            # droplet — an unfiltered prune here wipes the cache mounts that
-            # the prod deploy depends on (see deploy.yml).
+            # Staging still builds on-host, so prune only its own stale BuildKit
+            # cache (filtered to keep the last 24h warm). Prod no longer builds
+            # on this droplet, so nothing here protects the prod deploy anymore.
             docker builder prune -af --filter "until=24h" || true
 
             # Clone on first deploy, otherwise just fetch
@@ -115,10 +114,9 @@ jobs:
             # DB container is briefly down during a deploy (data-loss footgun on a
             # box whose only backup is a pg_dump to the same disk).
             docker image prune -af --filter "until=24h" || true
-            # Filter mirrors the image prune above. Critical because staging
-            # and prod share the same docker daemon / BuildKit instance on this
-            # droplet — an unfiltered prune here wipes the cache mounts that
-            # the prod deploy depends on (see deploy.yml).
+            # Staging still builds on-host, so prune only its own stale BuildKit
+            # cache (filtered to keep the last 24h warm). Prod no longer builds
+            # on this droplet, so nothing here protects the prod deploy anymore.
             docker builder prune -af --filter "until=24h" || true
 
             # Nothing to roll back if staging was never deployed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,16 +3,77 @@ name: Deploy to Production
 on:
   push:
     branches: [main]
+  # Manual trigger builds + pushes images WITHOUT deploying — used to publish
+  # the GHCR packages the first time (so they can be made public) before the
+  # first pull-based deploy. The deploy job is gated to `push` only (see below).
+  workflow_dispatch:
 
 concurrency:
   group: production-deploy
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Deploy
+  build:
+    name: Build & push images
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - service: api
+            dockerfile: ./packages/api/Dockerfile
+            build-args: ""
+          - service: web
+            dockerfile: ./packages/ui/Dockerfile
+            # Baked at build time (Vite). Must match today's prod value so the
+            # image is behavior-identical. Non-secret (it's a public URL).
+            build-args: |
+              VITE_API_URL=https://api.track.alfredo.re
+          - service: landing
+            dockerfile: ./packages/landing/Dockerfile
+            build-args: |
+              PUBLIC_URL=/
+              VITE_APP_URL=https://app.track.alfredo.re
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: production
+          build-args: ${{ matrix.build-args }}
+          push: true
+          # Moving tag `prod` is what the droplet pulls; immutable `sha-<commit>`
+          # is the manual rollback handle (docker pull <sha> && up -d).
+          tags: |
+            ghcr.io/alfredoreduarte/timetrack-${{ matrix.service }}:prod
+            ghcr.io/alfredoreduarte/timetrack-${{ matrix.service }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/alfredoreduarte/timetrack
+
+  deploy:
+    name: Deploy to production
+    needs: build
+    # Only deploy on push to main. A manual workflow_dispatch run just publishes
+    # images (bootstrap), it does not touch the running site.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Deploy via SSH
@@ -21,29 +82,19 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          # Bumped from 25m. Cold-cache web builds were hanging npm ci past
-          # the cap; the builder-prune filter below should keep the cache warm
-          # going forward, but headroom is cheap insurance.
-          command_timeout: 40m
+          command_timeout: 10m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"
             DEPLOY_DIR=~/websites/timetrack-production
 
             echo "=== Freeing disk space ==="
-            # Images only — never --volumes. The until= filter does NOT apply to
-            # volumes, so `system prune --volumes` can delete postgres_data if the
-            # DB container is briefly down during a deploy (data-loss footgun on a
-            # box whose only backup is a pg_dump to the same disk).
+            # Images only — never --volumes (the until= filter does not protect
+            # volumes; --volumes could delete postgres_data).
             docker image prune -af --filter "until=24h" || true
-            # Keep BuildKit cache from the last 24h so the npm ci cache mounts
-            # added in #125 (cd1da9 etc.) actually survive deploy-to-deploy.
-            # Without the filter, every deploy starts from cold cache and the
-            # web container's npm ci over the full monorepo can blow the SSH
-            # command_timeout (root cause of today's PR #143/#144 failures).
-            docker builder prune -af --filter "until=24h" || true
 
-            # Clone on first deploy, otherwise just fetch
+            # Clone on first deploy, otherwise just fetch. The host still needs
+            # the repo for the compose file, deploy.sh, and init.sql.
             if [ ! -d "$DEPLOY_DIR/.git" ]; then
               echo "=== First deploy: cloning repo ==="
               git clone "$REPO_URL" "$DEPLOY_DIR"
@@ -51,14 +102,14 @@ jobs:
 
             cd "$DEPLOY_DIR"
 
-            echo "=== Pulling latest changes ==="
+            echo "=== Pulling latest compose/config ==="
             git fetch --prune origin main
             git reset --hard origin/main
 
-            echo "=== Deploying ==="
+            echo "=== Deploying (pull prebuilt images — no on-host build) ==="
             ./deploy.sh prod
 
-            echo "=== Verifying health ==="
+            echo "=== Verifying container health ==="
             for service in "3011/health" "3010/health"; do
               echo "Waiting for localhost:${service}..."
               for i in $(seq 1 30); do
@@ -74,5 +125,14 @@ jobs:
                 sleep 2
               done
             done
+
+            # Functional check through the public API edge (host nginx -> api
+            # container). The web container's /health is a static nginx 200 and
+            # would pass even if the SPA could not reach the API, so verify the
+            # real edge here.
+            echo "=== Verifying public API edge ==="
+            curl -fsS https://api.track.alfredo.re/health > /dev/null \
+              && echo "✓ https://api.track.alfredo.re/health OK" \
+              || { echo "✗ public API edge unreachable"; exit 1; }
 
             echo "=== Deploy complete ==="

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ concurrency:
   group: production-deploy
   cancel-in-progress: true
 
+# Floor the token to read-only by default; the build job widens it to
+# packages: write for itself. The deploy job needs no token scope (SSH only).
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & push images
@@ -82,7 +87,9 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          command_timeout: 10m
+          # Pull-only deploy is fast, but the FIRST pull (or any after an image
+          # prune) downloads three full images cold — keep headroom over 10m.
+          command_timeout: 15m
           script: |
             set -euo pipefail
             REPO_URL="https://github.com/alfredoreduarte/timetrack.git"

--- a/deploy.sh
+++ b/deploy.sh
@@ -180,6 +180,8 @@ deploy() {
     elif [ "$mode" = "staging" ]; then
         # Staging still builds on-host. Migration to CI-built images is tracked
         # separately (per-PR + rollback need staging-baked frontend URLs).
+        # Build sequentially (not a single `build`) to avoid overwhelming the
+        # shared 1.9GB droplet's memory while old containers keep serving.
         log_info "Building new images (old containers still serving traffic)..."
         docker_compose -f "$compose_file" build api
         docker_compose -f "$compose_file" build web

--- a/deploy.sh
+++ b/deploy.sh
@@ -167,16 +167,24 @@ deploy() {
     source "$env_file"
     set +a
 
-    if [ "$mode" = "prod" ] || [ "$mode" = "staging" ]; then
-        # Build new images while old containers keep serving traffic.
-        # Sequential builds avoid overwhelming the server when cache is cold.
+    if [ "$mode" = "prod" ]; then
+        # Images are built in CI and pushed to GHCR (.github/workflows/deploy.yml).
+        # The host only PULLS prebuilt images — no on-host build, no OOM risk.
+        log_info "Pulling prebuilt images from registry..."
+        docker_compose -f "$compose_file" pull
+
+        # Recreate only containers whose image/config changed.
+        # Postgres and redis are untouched (stock images, no rebuild needed).
+        log_info "Replacing containers with new images..."
+        docker_compose -f "$compose_file" up -d --remove-orphans
+    elif [ "$mode" = "staging" ]; then
+        # Staging still builds on-host. Migration to CI-built images is tracked
+        # separately (per-PR + rollback need staging-baked frontend URLs).
         log_info "Building new images (old containers still serving traffic)..."
         docker_compose -f "$compose_file" build api
         docker_compose -f "$compose_file" build web
         docker_compose -f "$compose_file" build landing
 
-        # Recreate only containers whose image/config changed.
-        # Postgres and redis are untouched (stock images, no rebuild needed).
         log_info "Replacing containers with new images..."
         docker_compose -f "$compose_file" up -d --remove-orphans
     else

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,10 +29,8 @@ services:
 
   # API Service
   api:
-    build:
-      context: .
-      dockerfile: ./packages/api/Dockerfile
-      target: production
+    # Built in CI, pulled from GHCR (no on-host build). See deploy.yml.
+    image: ghcr.io/alfredoreduarte/timetrack-api:prod
     container_name: timetrack-api-prod
     restart: unless-stopped
     env_file: docker.env
@@ -69,12 +67,8 @@ services:
 
   # Web UI Service (includes nginx for serving React app and proxying API)
   web:
-    build:
-      context: .
-      dockerfile: ./packages/ui/Dockerfile
-      target: production
-      args:
-        VITE_API_URL: ${VITE_API_URL}
+    # Built in CI with VITE_API_URL baked in, pulled from GHCR. See deploy.yml.
+    image: ghcr.io/alfredoreduarte/timetrack-web:prod
     container_name: timetrack-web-prod
     restart: unless-stopped
     env_file: docker.env
@@ -113,13 +107,8 @@ services:
 
   # Marketing Landing Service (static nginx)
   landing:
-    build:
-      context: .
-      dockerfile: ./packages/landing/Dockerfile
-      target: production
-      args:
-        PUBLIC_URL: "/"
-        VITE_APP_URL: "${VITE_APP_URL:-https://app.track.alfredo.re}"
+    # Built in CI with PUBLIC_URL / VITE_APP_URL baked in, pulled from GHCR.
+    image: ghcr.io/alfredoreduarte/timetrack-landing:prod
     container_name: timetrack-landing-prod
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Stacked on #151 (the prune safety fix). Implements the **prod** half of issue #149: stop building Docker images on the live droplet — the on-host `npm ci` for the web image OOM-killed the running API mid-deploy.

## What changes
- **`.github/workflows/deploy.yml`** — new `build` job (matrix over api/web/landing) builds on the GH runner and pushes to **public GHCR**, tagged `:prod` (moving, what the host pulls) + `:sha-<commit>` (immutable rollback handle). The `deploy` job `needs:` the build (so a partial push never deploys), then SSHes to `docker compose pull` + `up -d` — **no on-host build**.
- web/landing baked with the **current prod URLs** (`VITE_API_URL=https://api.track.alfredo.re`, `VITE_APP_URL=https://app.track.alfredo.re`) so images are behavior-identical to today; api image is env-agnostic.
- **`deploy.sh`** — prod path now `docker compose pull`; **staging still builds on-host** (its migration needs staging-baked frontend URLs + rollback handling — separate PR).
- **`docker-compose.prod.yml`** — api/web/landing now `image: ghcr.io/alfredoreduarte/timetrack-*:prod` with **no `build:` keys**.
- Functional post-deploy check hits `https://api.track.alfredo.re/health` (the web container's `/health` is a static 200 and can't detect a broken API URL — this is the gap behind the original CORS/Network-Error symptom).
- Dropped the on-host `docker builder prune` and the 40m SSH timeout (now ~10m, pull-only).

## Scope note
**Prod only.** Staging (per-PR images + rollback-to-main) is deliberately deferred — a prod-tagged image can't serve staging (wrong baked API URL), so it needs its own design. Tracked as a follow-up to #149.

## ⚠️ One-time bootstrap (must happen before this is relied on)
GHCR packages are created private on first push. Before the first push-deploy:
1. Run this workflow via **workflow_dispatch** on this branch → publishes the 3 packages (build only, no deploy).
2. Set `timetrack-{api,web,landing}` packages to **public** in GitHub package settings.
3. Verify: `ssh root@track.alfredo.re docker pull ghcr.io/alfredoreduarte/timetrack-api:prod`.

## Test plan
- [ ] Bootstrap steps above completed; `docker pull` from droplet works.
- [ ] Merge → deploy runs build (3 images pushed) then deploy (pull + up -d), **no `npm ci`/buildkit on the droplet** during deploy (`ps`/`docker events`).
- [ ] `https://api.track.alfredo.re/health` stays up throughout; browser login works.
- [ ] Running timer / DB untouched (`pg_dump` still taken; Prisma `migrate deploy` still runs at API start).
- [ ] Deploy completes in single-digit minutes.

## Rollback
Re-deploy a prior image by SHA: `export and docker pull ghcr.io/.../timetrack-<svc>:sha-<prev> && docker compose up -d`. Note: image rollback does NOT revert DB migrations — that's what the pre-deploy `pg_dump` is for.

Refs #149