### PR TITLE
Live dashboard stats: Today & This Week tick up with running timers

### DIFF
--- a/packages/ui/src/pages/Dashboard.tsx
+++ b/packages/ui/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { AppDispatch, RootState } from "../store";
 import { useTimer } from "../hooks/useTimer";
 import {
   fetchDashboardEarnings,
-  updateCurrentTimerEarnings,
+  selectLiveEarnings,
 } from "../store/slices/dashboardSlice";
 import { fetchTimeEntries, TimeEntry } from "../store/slices/timeEntriesSlice";
 import { fetchProjects } from "../store/slices/projectsSlice";
@@ -20,11 +20,15 @@ const Dashboard: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   // Use centralized timer hook
-  const { isRunning, currentEntry, elapsedTime, startTimer } = useTimer();
+  const { isRunning, startTimer } = useTimer();
 
   const { earnings, loading: earningsLoading } = useSelector(
     (state: RootState) => state.dashboard
   );
+  // Today / This Week / Earning Now all read from one derived source so they
+  // tick up together while a timer runs. See selectLiveEarnings for how the
+  // live portion is computed (idempotent, summed across all running timers).
+  const liveEarnings = useSelector(selectLiveEarnings);
   const { entries: timeEntries } = useSelector(
     (state: RootState) => state.timeEntries
   );
@@ -33,43 +37,17 @@ const Dashboard: React.FC = () => {
   // Safe defaults to prevent undefined errors
   const safeTimeEntries = Array.isArray(timeEntries) ? timeEntries : [];
 
+  // Only show the loading placeholder on the very first fetch — once we have
+  // earnings, keep rendering the live values through background refetches so
+  // Today / This Week don't blink back to "..." every time a timer stops.
+  const showEarningsPlaceholder = earningsLoading && !earnings;
+
   // Fetch earnings data on component mount
   useEffect(() => {
     dispatch(fetchDashboardEarnings());
     dispatch(fetchTimeEntries({ limit: 5 })); // Fetch recent entries for the section
     dispatch(fetchProjects()); // Fetch projects for the recent entries
   }, [dispatch]);
-
-  // Update current timer earnings in real-time
-  useEffect(() => {
-    if (
-      isRunning &&
-      currentEntry &&
-      earnings?.currentTimer?.isRunning &&
-      earnings?.currentTimer?.hourlyRate !== undefined &&
-      earnings?.currentTimer?.hourlyRate !== null
-    ) {
-      dispatch(
-        updateCurrentTimerEarnings({
-          duration: elapsedTime,
-          hourlyRate: earnings.currentTimer.hourlyRate,
-        })
-      );
-    }
-  }, [
-    dispatch,
-    isRunning,
-    elapsedTime,
-    currentEntry,
-    earnings?.currentTimer?.isRunning,
-    earnings?.currentTimer?.hourlyRate,
-  ]);
-
-  // Calculate current timer earnings in real-time
-  const getCurrentTimerEarnings = (): number => {
-    if (!isRunning || earnings?.currentTimer?.hourlyRate === undefined || earnings?.currentTimer?.hourlyRate === null) return 0;
-    return (earnings.currentTimer.hourlyRate * elapsedTime) / 3600;
-  };
 
   // Handle resume timer from entry
   const handleResumeTimer = async (entry: TimeEntry) => {
@@ -123,12 +101,9 @@ const Dashboard: React.FC = () => {
               <div className="flex-1">
                 <p className="text-sm font-medium text-gray-600">Today</p>
                 <p className="text-xl font-bold text-gray-900 tabular-nums">
-                  {earningsLoading
+                  {showEarningsPlaceholder
                     ? "..."
-                    : `$${(typeof earnings?.today === "object"
-                        ? earnings.today.earnings
-                        : 0
-                      ).toFixed(2)}`}
+                    : `$${liveEarnings.today.toFixed(2)}`}
                 </p>
               </div>
               <div className="h-10 w-10 bg-blue-50 rounded-lg flex items-center justify-center">
@@ -143,12 +118,9 @@ const Dashboard: React.FC = () => {
               <div className="flex-1">
                 <p className="text-sm font-medium text-gray-600">This Week</p>
                 <p className="text-xl font-bold text-gray-900 tabular-nums">
-                  {earningsLoading
+                  {showEarningsPlaceholder
                     ? "..."
-                    : `$${(typeof earnings?.thisWeek === "object"
-                        ? earnings.thisWeek.earnings
-                        : 0
-                      ).toFixed(2)}`}
+                    : `$${liveEarnings.thisWeek.toFixed(2)}`}
                 </p>
               </div>
               <div className="h-10 w-10 bg-green-50 rounded-lg flex items-center justify-center">
@@ -158,25 +130,23 @@ const Dashboard: React.FC = () => {
           </div>
 
           {/* Currently Earning */}
-          {earnings?.currentTimer?.hourlyRate !== undefined &&
-            earnings?.currentTimer?.hourlyRate !== null &&
-            earnings.currentTimer.hourlyRate > 0 && (
-              <div className="card p-4 bg-green-50 border-green-200">
-                <div className="flex items-center">
-                  <div className="flex-1">
-                    <p className="text-sm font-medium text-green-600">
-                      Earning Now
-                    </p>
-                    <p className="text-xl font-bold text-green-700 tabular-nums">
-                      ${getCurrentTimerEarnings().toFixed(2)}
-                    </p>
-                  </div>
-                  <div className="h-10 w-10 bg-green-100 rounded-lg flex items-center justify-center">
-                    <ClockIcon className="h-5 w-5 text-green-600 animate-pulse" />
-                  </div>
+          {liveEarnings.isEarning && (
+            <div className="card p-4 bg-green-50 border-green-200">
+              <div className="flex items-center">
+                <div className="flex-1">
+                  <p className="text-sm font-medium text-green-600">
+                    Earning Now
+                  </p>
+                  <p className="text-xl font-bold text-green-700 tabular-nums">
+                    ${liveEarnings.currentTimer.toFixed(2)}
+                  </p>
+                </div>
+                <div className="h-10 w-10 bg-green-100 rounded-lg flex items-center justify-center">
+                  <ClockIcon className="h-5 w-5 text-green-600 animate-pulse" />
                 </div>
               </div>
-            )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/packages/ui/src/store/slices/__tests__/dashboardSlice.test.ts
+++ b/packages/ui/src/store/slices/__tests__/dashboardSlice.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import dashboardReducer, {
+  computeLiveEarnings,
+  selectLiveEarnings,
+  DashboardEarnings,
+} from "../dashboardSlice";
+import timerReducer, { tick } from "../timerSlice";
+import type { TimeEntry } from "../timeEntriesSlice";
+
+const baseEarnings = (today: number, thisWeek: number): DashboardEarnings => ({
+  currentTimer: { earnings: 0, duration: 0, isRunning: false, hourlyRate: 0 },
+  today: { earnings: today, duration: 0 },
+  thisWeek: { earnings: thisWeek, duration: 0 },
+});
+
+const runningEntry = (
+  id: string,
+  startTime: string,
+  hourlyRateSnapshot: number | null,
+  hasProject = true
+): TimeEntry => ({
+  id,
+  startTime,
+  duration: null,
+  hourlyRateSnapshot,
+  // Running entries from the API carry a nested `project` (null when absent),
+  // not a flat projectId — the today/thisWeek filter keys off its presence.
+  ...(hasProject ? { project: { id: `proj-${id}`, name: "Project" } } : {}),
+});
+
+// A Wednesday at noon. Week starts Monday 2026-06-15, day starts 2026-06-17.
+const NOW = new Date("2026-06-17T12:00:00").getTime();
+
+describe("computeLiveEarnings", () => {
+  it("returns the fetched base untouched when nothing is running", () => {
+    const result = computeLiveEarnings(baseEarnings(91.83, 582.11), [], {}, NOW);
+    expect(result.today).toBeCloseTo(91.83);
+    expect(result.thisWeek).toBeCloseTo(582.11);
+    expect(result.currentTimer).toBe(0);
+    expect(result.isRunning).toBe(false);
+  });
+
+  it("folds a running timer's live earnings into today and this week", () => {
+    // Rate 3600/hr == $1/sec, so 5s elapsed == $5.
+    const entries = [runningEntry("a", "2026-06-17T09:00:00", 3600)];
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 5 },
+      NOW
+    );
+    expect(result.currentTimer).toBeCloseTo(5);
+    expect(result.today).toBeCloseTo(105);
+    expect(result.thisWeek).toBeCloseTo(505);
+    expect(result.isRunning).toBe(true);
+  });
+
+  it("sums concurrent timers, counting each exactly once", () => {
+    // Regression guard for the 'two timers running' class of bug: each running
+    // timer must contribute its own earnings once, never doubled or shared.
+    const entries = [
+      runningEntry("a", "2026-06-17T09:00:00", 3600), // 5s -> $5
+      runningEntry("b", "2026-06-17T10:00:00", 7200), // 10s -> $20
+    ];
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 5, b: 10 },
+      NOW
+    );
+    expect(result.currentTimer).toBeCloseTo(25);
+    expect(result.today).toBeCloseTo(125);
+    expect(result.thisWeek).toBeCloseTo(525);
+  });
+
+  it("ignores running timers with no hourly rate", () => {
+    const entries = [
+      runningEntry("a", "2026-06-17T09:00:00", null),
+      runningEntry("b", "2026-06-17T10:00:00", 0),
+    ];
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 999, b: 999 },
+      NOW
+    );
+    expect(result.currentTimer).toBe(0);
+    expect(result.today).toBe(100);
+    expect(result.thisWeek).toBe(500);
+  });
+
+  it("buckets an overnight timer into this week but not today", () => {
+    // Started Tuesday 23:00 — before today's start, but still inside this week.
+    // Matches how the API buckets the entry (by startTime) once it stops, so
+    // the displayed totals stay continuous across the stop + refetch.
+    const entries = [runningEntry("a", "2026-06-16T23:00:00", 1)]; // 7200s @ $1/hr -> $2
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 7200 },
+      NOW
+    );
+    expect(result.currentTimer).toBeCloseTo(2);
+    expect(result.today).toBe(100); // excluded from today
+    expect(result.thisWeek).toBeCloseTo(502); // included in this week
+  });
+
+  it("works with no fetched base yet (delta only)", () => {
+    const entries = [runningEntry("a", "2026-06-17T09:00:00", 3600)];
+    const result = computeLiveEarnings(null, entries, { a: 5 }, NOW);
+    expect(result.today).toBeCloseTo(5);
+    expect(result.thisWeek).toBeCloseTo(5);
+  });
+
+  it("buckets concurrent timers across day and week boundaries independently", () => {
+    // Three timers running at once, each started at a different point:
+    //   a - today                -> counts toward today AND this week
+    //   b - Monday (this week)   -> counts toward this week only
+    //   c - last week (Sunday)   -> counts toward neither, but still earning
+    // All three appear in currentTimer / Earning Now.
+    const entries = [
+      runningEntry("a", "2026-06-17T09:00:00", 3600), // 5s  -> $5
+      runningEntry("b", "2026-06-15T10:00:00", 3600), // 10s -> $10
+      runningEntry("c", "2026-06-14T10:00:00", 3600), // 20s -> $20
+    ];
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 5, b: 10, c: 20 },
+      NOW
+    );
+    expect(result.today).toBeCloseTo(105); // base + a
+    expect(result.thisWeek).toBeCloseTo(515); // base + a + b
+    expect(result.currentTimer).toBeCloseTo(35); // a + b + c
+    expect(result.isEarning).toBe(true);
+  });
+
+  it("keeps a project-less timer out of today/this week but in Earning Now", () => {
+    // A timer started without a project still earns at the user's default rate,
+    // but the API excludes project-less entries from today/thisWeek. If we
+    // folded it into those totals it would vanish downward the moment it stops.
+    const entries = [
+      runningEntry("a", "2026-06-17T09:00:00", 3600, /* hasProject */ false),
+    ];
+    const result = computeLiveEarnings(
+      baseEarnings(100, 500),
+      entries,
+      { a: 5 },
+      NOW
+    );
+    expect(result.today).toBe(100); // excluded
+    expect(result.thisWeek).toBe(500); // excluded
+    expect(result.currentTimer).toBeCloseTo(5); // still earning
+    expect(result.isEarning).toBe(true);
+  });
+
+  it("reports isEarning false when nothing is running or nothing is paid", () => {
+    expect(computeLiveEarnings(baseEarnings(0, 0), [], {}, NOW).isEarning).toBe(
+      false
+    );
+    const unpaid = [runningEntry("a", "2026-06-17T09:00:00", 0)];
+    expect(
+      computeLiveEarnings(baseEarnings(0, 0), unpaid, { a: 5 }, NOW).isEarning
+    ).toBe(false);
+  });
+});
+
+describe("selectLiveEarnings (live ticking through the store)", () => {
+  const makeStore = () =>
+    configureStore({ reducer: { dashboard: dashboardReducer, timer: timerReducer } });
+
+  it("advances Today and This Week in lockstep with the timer tick", () => {
+    vi.useFakeTimers();
+    try {
+      const t0 = new Date("2026-06-17T12:00:00");
+      vi.setSystemTime(t0);
+
+      const store = makeStore();
+
+      // Fetched base: $100 today, $500 this week (stopped entries only).
+      store.dispatch({
+        type: "dashboard/fetchEarnings/fulfilled",
+        payload: baseEarnings(100, 500),
+      });
+
+      // A running timer at $1/sec, started "now".
+      store.dispatch({
+        type: "timer/startTimer/fulfilled",
+        payload: runningEntry("a", t0.toISOString(), 3600),
+      });
+
+      // Baseline: no elapsed yet.
+      let live = selectLiveEarnings(store.getState() as any);
+      expect(live.today).toBeCloseTo(100);
+      expect(live.thisWeek).toBeCloseTo(500);
+
+      // 5 seconds later + a tick -> +$5 everywhere.
+      vi.setSystemTime(new Date(t0.getTime() + 5_000));
+      store.dispatch(tick());
+      live = selectLiveEarnings(store.getState() as any);
+      expect(live.currentTimer).toBeCloseTo(5);
+      expect(live.today).toBeCloseTo(105);
+      expect(live.thisWeek).toBeCloseTo(505);
+
+      // 10 seconds -> +$10. The totals keep climbing with wall-clock time.
+      vi.setSystemTime(new Date(t0.getTime() + 10_000));
+      store.dispatch(tick());
+      live = selectLiveEarnings(store.getState() as any);
+      expect(live.today).toBeCloseTo(110);
+      expect(live.thisWeek).toBeCloseTo(510);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not accumulate when the same instant is ticked many times", () => {
+    // Guards the regression this whole approach is built to avoid: multiple
+    // useTimer() instances each fire tick() every second, so at one wall-clock
+    // instant the reducer is dispatched N times. Because earnings derive from
+    // elapsed (recomputed from startTime), repeated ticks at a fixed instant
+    // must NOT push Today/This Week past their true value.
+    vi.useFakeTimers();
+    try {
+      const t0 = new Date("2026-06-17T12:00:00");
+      vi.setSystemTime(t0);
+
+      const store = makeStore();
+      store.dispatch({
+        type: "dashboard/fetchEarnings/fulfilled",
+        payload: baseEarnings(100, 500),
+      });
+      store.dispatch({
+        type: "timer/startTimer/fulfilled",
+        payload: runningEntry("a", t0.toISOString(), 3600),
+      });
+
+      vi.setSystemTime(new Date(t0.getTime() + 5_000));
+      for (let i = 0; i < 20; i++) store.dispatch(tick());
+
+      const live = selectLiveEarnings(store.getState() as any);
+      expect(live.today).toBeCloseTo(105); // not 100 + 20*5
+      expect(live.thisWeek).toBeCloseTo(505);
+      expect(live.currentTimer).toBeCloseTo(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/store/slices/dashboardSlice.ts
+++ b/packages/ui/src/store/slices/dashboardSlice.ts
@@ -1,5 +1,7 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk, createSelector } from "@reduxjs/toolkit";
 import { authAPI } from "../../services/api";
+import type { RootState } from "../index";
+import type { TimeEntry } from "./timeEntriesSlice";
 
 export interface DashboardEarnings {
   currentTimer: {
@@ -59,13 +61,6 @@ const dashboardSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
-    updateCurrentTimerEarnings: (state, action) => {
-      if (state.earnings?.currentTimer.isRunning) {
-        const { duration, hourlyRate } = action.payload;
-        state.earnings.currentTimer.duration = duration;
-        state.earnings.currentTimer.earnings = (hourlyRate * duration) / 3600;
-      }
-    },
   },
   extraReducers: (builder) => {
     builder
@@ -84,6 +79,118 @@ const dashboardSlice = createSlice({
   },
 });
 
-export const { clearError, updateCurrentTimerEarnings } =
-  dashboardSlice.actions;
+export const { clearError } = dashboardSlice.actions;
 export default dashboardSlice.reducer;
+
+// ---------------------------------------------------------------------------
+// Live earnings
+//
+// The API's today/thisWeek totals only sum *stopped* entries — a running timer
+// is reported separately as `currentTimer`. To make Today and This Week tick up
+// live (like Earning Now) we fold each running timer's live earnings back into
+// those totals, deriving the live portion from wall-clock elapsed rather than
+// accumulating it. That derivation is idempotent: it doesn't matter how many
+// components subscribe or how often the selector recomputes, the value only
+// depends on the current time — the same property that fixed the "N seconds per
+// second" tick bug. It also sums across *all* running timers, so concurrent
+// timers each contribute exactly once.
+//
+// The running-timer deltas are bucketed to match the API's own filters (start
+// day/week, and project-attached only) so the amount a timer contributes is the
+// same before and after it stops — the only movement at stop is the brief lag
+// while the base total refetches from the server.
+// ---------------------------------------------------------------------------
+
+export interface LiveEarnings {
+  today: number;
+  thisWeek: number;
+  currentTimer: number;
+  isRunning: boolean;
+  // True when at least one running timer has a positive rate — i.e. money is
+  // actively being earned right now. Drives the "Earning Now" card so it shows
+  // immediately on start rather than waiting for the first tick.
+  isEarning: boolean;
+}
+
+// Start of the local day, in ms. The browser's local timezone is the one sent
+// to /dashboard-earnings, so this lines up with the server's day bucketing.
+const startOfLocalDay = (nowMs: number): number => {
+  const d = new Date(nowMs);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+// Start of the local week (Monday), in ms — mirrors getStartOfWeekInTimezone on
+// the API so a running timer buckets into "this week" exactly as it will once
+// it's stopped and folded into the fetched total.
+const startOfLocalWeek = (nowMs: number): number => {
+  const d = new Date(nowMs);
+  const dayOfWeek = d.getDay(); // 0 = Sunday
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  d.setDate(d.getDate() - daysToMonday);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+// Pure: base (stopped) earnings + each running timer's live earnings. Each
+// timer's day/week contribution is bucketed by when it *started*, matching how
+// the API will bucket the entry once it stops — so the amount it accounts for
+// doesn't jump across the stop.
+export const computeLiveEarnings = (
+  earnings: DashboardEarnings | null,
+  runningEntries: TimeEntry[],
+  elapsedById: Record<string, number>,
+  nowMs: number
+): LiveEarnings => {
+  const dayStart = startOfLocalDay(nowMs);
+  const weekStart = startOfLocalWeek(nowMs);
+
+  let todayDelta = 0;
+  let weekDelta = 0;
+  let currentTimer = 0;
+  let isEarning = false;
+
+  for (const entry of runningEntries) {
+    const rate = entry.hourlyRateSnapshot ?? 0;
+    if (!rate) continue;
+    isEarning = true;
+
+    const elapsed = elapsedById[entry.id] ?? 0;
+    const live = (rate * elapsed) / 3600;
+    // Earning Now mirrors the API's currentTimer query, which has no project
+    // filter — so every paid running timer counts here.
+    currentTimer += live;
+
+    // Today / This Week only sum project-attached entries, because the API's
+    // today/thisWeek queries filter `projectId: not null`. A project-less timer
+    // still earns at the user's default rate, but folding it into these totals
+    // would make it vanish the instant it stops and the base refetches (the
+    // server never counts it there). Keep it out to stay consistent.
+    const hasProject = !!(entry.project || entry.projectId);
+    if (!hasProject) continue;
+
+    const startMs = entry.startTime ? new Date(entry.startTime).getTime() : NaN;
+    if (Number.isFinite(startMs)) {
+      if (startMs >= dayStart) todayDelta += live;
+      if (startMs >= weekStart) weekDelta += live;
+    }
+  }
+
+  return {
+    today: (earnings?.today?.earnings ?? 0) + todayDelta,
+    thisWeek: (earnings?.thisWeek?.earnings ?? 0) + weekDelta,
+    currentTimer,
+    isRunning: runningEntries.length > 0,
+    isEarning,
+  };
+};
+
+export const selectLiveEarnings = createSelector(
+  [
+    (s: RootState) => s.dashboard.earnings,
+    (s: RootState) => s.timer.runningEntries,
+    (s: RootState) => s.timer.elapsedById,
+  ],
+  (earnings, runningEntries, elapsedById) =>
+    computeLiveEarnings(earnings, runningEntries, elapsedById, Date.now())
+);


### PR DESCRIPTION
## What & why

The dashboard's **Today** and **This Week** earnings cards were static snapshots from the last fetch — only **Earning Now** ticked up while a timer ran. This makes Today and This Week update live too, so all three cards climb together while you work.

The `/dashboard-earnings` API sums only *stopped* entries for Today/This Week and reports the running timer separately as `currentTimer`. Rather than accumulate a per-second counter (the pattern behind the recent "timer advances N seconds per second" bug), the live portion is **derived from wall-clock elapsed** and folded into the fetched base:

- **One derived source.** New `computeLiveEarnings` + memoized `selectLiveEarnings` selector combine `dashboard.earnings` with the running timers in `timer.runningEntries` / `elapsedById`. Today, This Week, and Earning Now all read from it, so they tick in lockstep.
- **Idempotent by construction.** The value depends only on elapsed time, not on how many components subscribe or how often the selector runs — so the multiple `useTimer()` mounts that caused the earlier double-counting bug can't inflate it here. A test ticks the same instant 20× and asserts no drift.
- **Concurrent timers each count once.** The delta sums across *all* running timers (not just the primary), directly covering the "two timers running" case.
- **Bucketed to match the server.** Each timer's Today/This-Week contribution is bucketed by its `startTime` (local day / Monday-week, matching the API's timezone bucketing) and restricted to project-attached timers — mirroring the API's `projectId: not null` filter. This keeps the amount a timer accounts for the same before and after it stops, so the totals don't jump when the base refetches.

Also removed the now-redundant per-tick `updateCurrentTimerEarnings` reducer/effect and the `getCurrentTimerEarnings` helper — the derived selector replaces them.

## Review

This went through a multi-agent review (correctness/math, React–Redux runtime, and tests). Findings addressed in the second commit:

- **Fixed (correctness):** a project-less running timer earns at the user's default rate but is *excluded* from the API's Today/This-Week totals; folding it in made it vanish downward on stop. The live delta now excludes project-less timers from Today/This Week while still showing them in Earning Now (matching the server's `currentTimer`).
- **Fixed (UX):** Earning Now now appears the instant a paid timer starts (gated on `isEarning`) instead of after the first tick.
- **Verified sound:** no double-counting, correct concurrent-timer summing, and client/server day/week (Monday-start) bucketing agree.

**Known minor follow-up (not in this PR):** on stop, Today/This Week can briefly dip while the base total refetches (the running delta clears immediately; the server-side base lands a beat later). It's a cosmetic timing artifact; the durable fix (optimistically absorbing the stopped entry) adds cross-slice coupling and stale-refetch edge cases, so it's left out here.

## Test plan

- [x] `npm run type-check:all` — clean across all packages
- [x] UI production build (`vite build`) — succeeds
- [x] New `dashboardSlice.test.ts` (11 tests): live ticking through the store, no-accumulation-on-repeated-tick guard, concurrent timers crossing day/week boundaries, project-less exclusion, overnight bucketing, unpaid/null-rate handling, `isEarning`
- [x] No change to the pre-existing UI test failures (unrelated: an MSW port mismatch and stale test strings that predate this branch)
- [ ] Manual: start one/two timers on the dashboard and confirm Today, This Week, and Earning Now all tick up together

## Files
- `packages/ui/src/store/slices/dashboardSlice.ts` — `computeLiveEarnings`, `selectLiveEarnings`; removed `updateCurrentTimerEarnings`
- `packages/ui/src/pages/Dashboard.tsx` — cards read from the derived selector
- `packages/ui/src/store/slices/__tests__/dashboardSlice.test.ts` — new tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01BgGMdHMfBjqugrPCDv5q7A)_